### PR TITLE
Standardize error terminology in default_policy JSON, TypeScript, and…

### DIFF
--- a/contract-integration/anchor/idl/default_policy.json
+++ b/contract-integration/anchor/idl/default_policy.json
@@ -146,7 +146,7 @@
     },
     {
       "code": 6001,
-      "name": "UnAuthorize",
+      "name": "Unauthorized",
       "msg": "Unauthorized to access smart wallet"
     }
   ],

--- a/contract-integration/anchor/types/default_policy.ts
+++ b/contract-integration/anchor/types/default_policy.ts
@@ -152,7 +152,7 @@ export type DefaultPolicy = {
     },
     {
       code: 6001;
-      name: 'unAuthorize';
+      name: 'unauthorized';
       msg: 'Unauthorized to access smart wallet';
     }
   ];

--- a/programs/default_policy/src/error.rs
+++ b/programs/default_policy/src/error.rs
@@ -5,5 +5,5 @@ pub enum PolicyError {
     #[msg("Invalid passkey format")]
     InvalidPasskey,
     #[msg("Unauthorized to access smart wallet")]
-    UnAuthorize,
+    Unauthorized,
 }

--- a/programs/default_policy/src/instructions/check_policy.rs
+++ b/programs/default_policy/src/instructions/check_policy.rs
@@ -15,8 +15,8 @@ pub struct CheckPolicy<'info> {
     #[account(
         mut,
         owner = ID,
-        constraint = wallet_device.key() == policy.wallet_device @ PolicyError::UnAuthorize,
-        constraint = policy.smart_wallet == smart_wallet.key() @ PolicyError::UnAuthorize,
+        constraint = wallet_device.key() == policy.wallet_device @ PolicyError::Unauthorized,
+        constraint = policy.smart_wallet == smart_wallet.key() @ PolicyError::Unauthorized,
     )]
     pub policy: Account<'info, Policy>,
 }

--- a/programs/lazorkit/src/instructions/execute/chunk/execute_session_transaction.rs
+++ b/programs/lazorkit/src/instructions/execute/chunk/execute_session_transaction.rs
@@ -53,7 +53,7 @@ pub fn execute_session_transaction(
 
     // Validate program is executable only (no whitelist/rule checks here)
     if !ctx.accounts.cpi_program.executable {
-        msg!("Cpi program must executable");
+        msg!("Cpi program must be executable");
         return Ok(());
     }
 

--- a/programs/lazorkit/src/security.rs
+++ b/programs/lazorkit/src/security.rs
@@ -1,7 +1,5 @@
 use anchor_lang::prelude::*;
 
-use crate::error::LazorKitError;
-
 // Security constants and validation utilities
 
 /// Maximum allowed size for credential ID to prevent DoS
@@ -99,7 +97,10 @@ pub mod validation {
     pub fn validate_program_executable(program: &AccountInfo) -> Result<()> {
         require!(program.executable, LazorKitError::ProgramNotExecutable);
 
-        require!(program.key() != crate::ID, LazorKitError::ReentrancyDetected);
+        require!(
+            program.key() != crate::ID,
+            LazorKitError::ReentrancyDetected
+        );
         Ok(())
     }
 


### PR DESCRIPTION
… Rust files by renaming "UnAuthorize" to "Unauthorized". Update related constraints in check_policy instructions for consistency. Improve clarity in error messages and ensure alignment across the codebase.