### PR TITLE
feat: deferred execution, odometer replay protection, Solita SDK, tx optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- Deferred Execution: 2-transaction flow for large payloads exceeding the ~574-byte limit of a single Secp256r1 Execute tx
+- Authorize instruction (disc=6): TX1 signs over instruction/account hashes, creates DeferredExec PDA
+- ExecuteDeferred instruction (disc=7): TX2 verifies hashes and executes via CPI with vault signing
+- ReclaimDeferred instruction (disc=8): closes expired DeferredExec accounts, refunds rent to original payer
+- DeferredExecAccount (176 bytes): stores instruction/account hashes, wallet, authority, payer, expiry
+- Deferred execution benchmarks (CU + tx size measurements for TX1/TX2)
+- Error codes 3014-3018 for deferred execution (expired, hash mismatch, invalid expiry, unauthorized reclaim)
+- SDK builders: `createAuthorizeIx`, `createExecuteDeferredIx`, `createReclaimDeferredIx`
+- SDK helpers: `findDeferredExecPda`, `computeInstructionsHash`
+- LazorKitClient methods: `authorizeSecp256r1`, `executeDeferredSecp256r1`, `reclaimDeferred`
+- 7 new integration tests for deferred execution (tests-sdk, total now 35)
 - Odometer counter replay protection for Secp256r1 (monotonic u32 per authority)
 - program_id included in challenge hash (cross-program replay prevention)
 - rpId stored on authority account at creation (saves ~14 bytes per transaction)
 - TypeScript SDK (`sdk/solita-client`) with Solita code generation
-- Integration test suite (`tests-sdk/`) with 28 tests across 7 files
+- Integration test suite (`tests-sdk/`) with 35 tests across 8 files
 - Benchmark script for CU and transaction size measurements
 - CompactInstructions accounts hash for anti-reordering protection
 - Session expiry validation (future check + 30-day max duration)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,7 +38,7 @@ cargo test
 ### C. IDL Generation (using Shank)
 
 ```bash
-cd program && shank idl -o . --out-filename idl.json -p 2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT
+cd program && shank idl -o . --out-filename idl.json -p FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao
 ```
 
 ### D. SDK Generation (using Solita)
@@ -55,7 +55,7 @@ The generate.mjs script reads the Shank IDL, enriches it with accounts/errors/ty
 # Terminal 1: Start local validator with program loaded
 cd tests-sdk && npm run validator:start
 
-# Terminal 2: Run all 28 tests
+# Terminal 2: Run all 35 tests
 cd tests-sdk && npm test
 ```
 
@@ -65,7 +65,7 @@ cd tests-sdk && npm test
 cd tests-sdk && npm run benchmark
 ```
 
-Measures CU usage and transaction sizes for all instructions.
+Measures CU usage and transaction sizes for all instructions, including deferred execution (Authorize TX1 + ExecuteDeferred TX2).
 
 ### G. Program ID Sync
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A high-performance smart wallet program on Solana with passkey (WebAuthn/Secp256r1) authentication, role-based access control, session keys, and replay-safe odometer counters. Built with [pinocchio](https://github.com/febo/pinocchio) for zero-copy serialization.
 
-**Program ID**: `2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT`
+**Program ID**: `FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao`
 
 ---
 
@@ -15,6 +15,7 @@ A high-performance smart wallet program on Solana with passkey (WebAuthn/Secp256
 - **Clock-Based Slot Freshness**: 150-slot window via `Clock::get()` — no SlotHashes sysvar needed
 - **Zero-Copy Serialization**: Raw byte casting via pinocchio, no Borsh overhead
 - **CompactInstructions**: Index-based instruction packing for multi-call payloads within Solana's 1,232-byte tx limit
+- **Deferred Execution**: 2-transaction flow for payloads exceeding the tx limit (e.g., Jupiter swaps) -- TX1 authorizes via signature, TX2 executes with full inner instruction space (~1,100 bytes)
 - **CPI Reentrancy Protection**: stack_height check prevents cross-program authentication attacks
 
 ---
@@ -23,13 +24,24 @@ A high-performance smart wallet program on Solana with passkey (WebAuthn/Secp256
 
 | Metric | Normal Transfer | LazorKit (Secp256r1) | LazorKit (Session) |
 |---|---|---|---|
-| Compute Units | 150 | 10,941 | 4,483 |
+| Compute Units | 150 | 12,441 | 8,983 |
 | Transaction Size | 215 bytes | 658 bytes | 452 bytes |
 | Accounts | 2 | 7 | 7 |
 | Instructions | 1 | 2 | 1 |
 | Transaction Fee | 0.000005 SOL | 0.000005 SOL | 0.000005 SOL |
 
-Session keys are ideal for frequent transactions — they skip the Secp256r1 precompile and use a simple Ed25519 signer, resulting in lower CU and smaller transactions.
+Session keys are ideal for frequent transactions -- they skip the Secp256r1 precompile and use a simple Ed25519 signer, resulting in lower CU and smaller transactions.
+
+### Deferred Execution (Large Payloads)
+
+For operations exceeding the ~574 bytes available in a single Secp256r1 Execute tx (e.g., Jupiter swaps):
+
+| Metric | Immediate Execute | Deferred (2 txs) |
+|---|---|---|
+| Total CU | 12,441 | 18,613 (11,709 + 6,904) |
+| Inner Ix Capacity | ~574 bytes | ~1,100 bytes (1.9x) |
+| Tx Fee | 0.000005 SOL | 0.00001 SOL |
+| Temp Rent | -- | 0.00212 SOL (refunded) |
 
 See [docs/Costs.md](docs/Costs.md) for full cost analysis, session key costs, and CU benchmarks for all instructions.
 
@@ -45,6 +57,7 @@ See [docs/Costs.md](docs/Costs.md) for full cost analysis, session key costs, an
 | Authority (Ed25519) | 80 bytes | 0.001448 |
 | Authority (Secp256r1) | ~125 bytes | 0.001761 |
 | Session | 80 bytes | 0.001448 |
+| DeferredExec | 176 bytes | 0.002116 (temporary, refunded) |
 
 ### Total Wallet Creation
 
@@ -72,6 +85,7 @@ Session rent is refundable after expiry. Ongoing Execute transactions cost only 
 | Vault PDA | `["vault", wallet]` | Holds SOL/tokens, program signs via PDA |
 | Authority PDA | `["authority", wallet, id_hash]` | Per-key auth with role + counter |
 | Session PDA | `["session", wallet, session_key]` | Ephemeral sub-key with expiry |
+| DeferredExec PDA | `["deferred", wallet, authority, counter]` | Temporary pre-authorized execution (176 bytes) |
 
 See [docs/Architecture.md](docs/Architecture.md) for struct definitions, security mechanisms, and instruction reference.
 
@@ -82,12 +96,12 @@ See [docs/Architecture.md](docs/Architecture.md) for struct definitions, securit
 ```
 program/src/           Rust smart contract (pinocchio, zero-copy)
   auth/                Ed25519 + Secp256r1/WebAuthn authentication
-  processor/           6 instruction handlers
+  processor/           9 instruction handlers
   state/               Account data structures (NoPadding)
 sdk/solita-client/     TypeScript SDK (Solita-generated + hand-written utils)
   src/generated/       Auto-generated instructions, accounts, errors
   src/utils/           Instruction builders, PDA helpers, signing utils
-tests-sdk/             Integration tests (vitest, 28 tests)
+tests-sdk/             Integration tests (vitest, 35 tests)
 docs/                  Architecture, cost analysis
 audits/                Audit reports
 ```
@@ -138,14 +152,14 @@ See [sdk/solita-client/README.md](sdk/solita-client/README.md) for full API refe
 # Start local validator with program loaded
 cd tests-sdk && npm run validator:start
 
-# Run all 28 integration tests
+# Run all 35 integration tests
 npm test
 
 # Run CU benchmarks
 npm run benchmark
 ```
 
-Tests cover: wallet lifecycle, authority management, execute, sessions, replay protection, counter edge cases, and end-to-end workflows.
+Tests cover: wallet lifecycle, authority management, execute, deferred execution, sessions, replay protection, counter edge cases, and end-to-end workflows.
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for full development workflow.
 

--- a/assertions/src/lib.rs
+++ b/assertions/src/lib.rs
@@ -11,7 +11,7 @@ use pinocchio_pubkey::declare_id;
 use pinocchio_system::ID as SYSTEM_ID;
 
 // LazorKit Program ID
-declare_id!("2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT");
+declare_id!("FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao");
 
 #[allow(unused_imports)]
 use std::mem::MaybeUninit;

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -48,6 +48,7 @@ pub enum AccountDiscriminator {
     Wallet = 1,
     Authority = 2,
     Session = 3,
+    DeferredExec = 4,
 }
 ```
 
@@ -109,13 +110,36 @@ pub struct SessionAccount {
 // Total: 1+1+1+5+32+32+8 = 80 bytes
 ```
 
-### D. Vault PDA
+### D. DeferredExecAccount (176 bytes)
+
+Seeds: `["deferred", wallet_pubkey, authority_pubkey, counter_le(4)]`
+
+```rust
+#[repr(C, align(8))]
+pub struct DeferredExecAccount {
+    pub discriminator: u8,           // 4 = DeferredExec
+    pub version: u8,
+    pub bump: u8,
+    pub _padding: [u8; 5],
+    pub instructions_hash: [u8; 32], // SHA256 of serialized compact instructions
+    pub accounts_hash: [u8; 32],     // SHA256 of all account pubkeys referenced
+    pub wallet: Pubkey,              // 32 bytes
+    pub authority: Pubkey,           // 32 bytes — the authority that authorized
+    pub payer: Pubkey,               // 32 bytes — receives rent refund on close
+    pub expires_at: u64,             // Absolute slot at which this expires
+}
+// Total: 1+1+1+5+32+32+32+32+32+8 = 176 bytes
+```
+
+Temporary account created during `Authorize` (tx1) and closed during `ExecuteDeferred` (tx2). Uses the authority's odometer counter as a seed nonce, ensuring unique PDAs per authorization. Expired accounts can be reclaimed via `ReclaimDeferred`.
+
+### E. Vault PDA
 
 Seeds: `["vault", wallet_pubkey]`
 
 No data allocated. Holds SOL. Program signs for it via PDA seeds during Execute.
 
-## 5. Instructions (6 total)
+## 5. Instructions (9 total)
 
 ### CreateWallet (discriminator: 0)
 
@@ -155,6 +179,35 @@ No data allocated. Holds SOL. Program signs for it via PDA seeds during Execute.
 - Validates expires_at: must be in future, max ~30 days.
 - Accounts: payer, wallet, authorizer, session, system_program, rent_sysvar.
 
+### Authorize (discriminator: 6) — Deferred Execution TX1
+
+- Creates a DeferredExec PDA storing pre-authorized instruction/account hashes.
+- Only Secp256r1 Owner/Admin can authorize (not Ed25519, not Spender).
+- Signed payload: `instructions_hash || accounts_hash` (64 bytes).
+- Expiry offset bounded to 10-9,000 slots (~4 seconds to ~1 hour).
+- Uses the authority's odometer counter (post-increment) as PDA seed nonce.
+- Instruction data: `[instructions_hash(32)][accounts_hash(32)][expiry_offset(2)][auth_payload(variable)]`.
+- Accounts: payer, wallet, authority, deferred_exec, system_program, rent_sysvar, sysvar_instructions.
+
+### ExecuteDeferred (discriminator: 7) — Deferred Execution TX2
+
+- Verifies compact instructions against stored hashes, executes via CPI with vault PDA signing.
+- Closes the DeferredExec account before CPI (close-before-execute pattern).
+- Verifies both instructions_hash and accounts_hash match stored values.
+- Checks expiry (must not be past `expires_at` slot).
+- Refunds rent to the original payer (stored in DeferredExec).
+- Self-reentrancy protection: rejects CPI back into this program.
+- Instruction data: `[compact_instructions(variable)]`.
+- Accounts: payer, wallet, vault, deferred_exec, refund_destination, [remaining accounts...].
+
+### ReclaimDeferred (discriminator: 8)
+
+- Closes an expired DeferredExec account and refunds rent to the original payer.
+- Only the original payer (stored in `deferred.payer`) can reclaim.
+- Can only be called after `expires_at` has passed.
+- No instruction data (discriminator only).
+- Accounts: payer, deferred_exec, refund_destination.
+
 ## 6. CompactInstructions Format
 
 Binary format for packing multiple instructions into Execute:
@@ -175,7 +228,32 @@ Overhead per instruction: 4 bytes + num_accounts. Replaces 32-byte pubkeys with 
 
 For Secp256r1 Execute, the signed payload includes a SHA256 hash of all account pubkeys referenced by the compact instructions. This prevents account reordering attacks where an attacker could swap recipient addresses while keeping the signature valid.
 
-## 7. Auth Payload Layout (Secp256r1)
+## 7. Deferred Execution
+
+2-transaction flow for payloads exceeding the ~574 bytes available in a single Secp256r1 Execute transaction (e.g., Jupiter swaps with complex routing).
+
+### Flow
+
+1. **TX1 (Authorize)**: Client computes `instructions_hash = SHA256(packed_compact_instructions)` and `accounts_hash = SHA256(all_referenced_pubkeys)`. These hashes are signed via Secp256r1 and stored in a DeferredExec PDA. The authority's odometer counter is incremented.
+2. **TX2 (ExecuteDeferred)**: Any signer submits the full compact instructions. The program verifies both hashes match, checks expiry, closes the DeferredExec account, and executes via CPI with vault signing.
+
+### Capacity
+
+| Path | Inner Ix Capacity | Total CU | Tx Fee |
+|---|---|---|---|
+| Immediate Execute | ~574 bytes | 12,441 | 0.000005 SOL |
+| Deferred (2 txs) | ~1,100 bytes (1.9x) | 18,613 | 0.00001 SOL |
+
+### Security Properties
+
+- **Hash binding**: Both instruction content and account ordering are hash-verified.
+- **Replay protection**: Odometer counter used as PDA seed nonce — each authorization gets a unique PDA.
+- **Expiry**: 10-9,000 slot window (~4s to ~1h). Prevents stale authorizations.
+- **Role gating**: Only Secp256r1 Owner/Admin can authorize.
+- **Close-before-CPI**: DeferredExec account is closed before CPI execution, avoiding stale-pointer issues with `invoke_signed_unchecked`. Transaction reverts atomically if any CPI fails.
+- **Rent recovery**: `ReclaimDeferred` allows original payer to reclaim rent from expired, unexecuted authorizations.
+
+## 8. Auth Payload Layout (Secp256r1)
 
 ```
 [slot: u64 LE]              // 8 bytes  -- Clock-based slot freshness
@@ -190,7 +268,7 @@ Compared to the previous layout, 3 optimizations reduce the per-transaction payl
 - **SlotHashes index**: removed (slot freshness via `Clock::get()` instead of sysvar lookup)
 - **rpId**: stored on the authority account at creation, not sent per-tx (saves ~12 bytes)
 
-## 8. Project Structure
+## 9. Project Structure
 
 ```
 program/
@@ -205,16 +283,20 @@ program/
     processor/
       create_wallet.rs
       manage_authority.rs     AddAuthority + RemoveAuthority
-      execute.rs              CompactInstruction execution
+      execute.rs              CompactInstruction execution (immediate)
+      authorize.rs            Deferred execution TX1 (creates DeferredExec PDA)
+      execute_deferred.rs     Deferred execution TX2 (verifies + executes)
+      reclaim_deferred.rs     Closes expired DeferredExec accounts
       create_session.rs
       transfer_ownership.rs
     state/
       wallet.rs               WalletAccount (8 bytes)
       authority.rs            AuthorityAccountHeader (48 bytes)
       session.rs              SessionAccount (80 bytes)
+      deferred.rs             DeferredExecAccount (176 bytes)
     compact.rs                CompactInstruction serialization
     utils.rs                  PDA initialization, stack_height check
-    error.rs                  AuthError enum (3001-3013)
+    error.rs                  AuthError enum (3001-3018)
     entrypoint.rs             Instruction routing
 sdk/solita-client/
   src/
@@ -226,5 +308,5 @@ sdk/solita-client/
       secp256r1.ts            Challenge hash + auth payload builders
       packing.ts              CompactInstruction packing
       errors.ts               Error code mapping
-tests-sdk/                    Integration tests (vitest, 28+ tests)
+tests-sdk/                    Integration tests (vitest, 35 tests)
 ```

--- a/docs/Costs.md
+++ b/docs/Costs.md
@@ -2,7 +2,7 @@
 
 This document provides comprehensive cost data for the LazorKit smart wallet program on Solana. All compute unit (CU) measurements are from real transactions against a local validator. Rent costs use Solana's standard formula.
 
-> Program ID: `2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT`
+> Program ID: `FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao`
 
 ---
 
@@ -14,8 +14,8 @@ This document provides comprehensive cost data for the LazorKit smart wallet pro
 | CreateWallet (Ed25519) | 15,187 | 408 | 73 | 6 | 1 |
 | CreateWallet (Secp256r1) | 13,687 | 453 | 118 | 6 | 1 |
 | AddAuthority (Ed25519 admin) | 5,846 | 473 | 41 | 7 | 1 |
-| Execute Secp256r1 (SOL transfer) | 10,941 | 658 | 254 | 7 | 2 |
-| Execute Session (SOL transfer) | 4,483 | 452 | 20 | 7 | 1 |
+| Execute Secp256r1 (SOL transfer) | 12,441 | 658 | 254 | 7 | 2 |
+| Execute Session (SOL transfer) | 8,983 | 452 | 20 | 7 | 1 |
 | CreateSession (Ed25519) | 6,015 | 473 | 41 | 7 | 1 |
 
 **Notes:**
@@ -24,6 +24,24 @@ This document provides comprehensive cost data for the LazorKit smart wallet pro
 - Session Execute is cheaper -- only 1 instruction, no precompile, no auth payload
 - All operations fit well within Solana's 200,000 CU default budget
 - Transaction sizes are well within Solana's 1,232-byte limit
+
+### Deferred Execution (Large Payloads)
+
+For operations exceeding the ~574 bytes available in a single Secp256r1 Execute transaction:
+
+| Instruction | CU | Tx Size (bytes) | Accounts | Instructions |
+|---|---|---|---|---|
+| Authorize (TX1) | 11,709 | 705 | 7 | 2 |
+| ExecuteDeferred (TX2, 1 inner ix) | 6,904 | 356 | 7 | 1 |
+
+| Metric | Immediate Execute | Deferred (2 txs) |
+|---|---|---|
+| Total CU | 12,441 | 18,613 (11,709 + 6,904) |
+| Inner Ix Capacity | ~574 bytes | ~1,100 bytes (1.9x) |
+| Tx Fee | 0.000005 SOL | 0.00001 SOL |
+| Temp Rent | -- | 0.002116 SOL (refunded) |
+
+The deferred path trades ~50% more total CU and 2x the tx fee for 1.9x the inner instruction space. The DeferredExec account rent (0.002116 SOL) is temporary -- it is refunded when TX2 executes or when the payer reclaims an expired authorization.
 
 ---
 
@@ -45,7 +63,7 @@ The Secp256r1 Execute transaction was optimized from **708 bytes to 658 bytes** 
 
 | Metric | Normal Transfer | LazorKit Secp256r1 | LazorKit Session | Notes |
 |---|---|---|---|---|
-| Compute Units | 150 | 10,941 | 4,483 | Session uses Ed25519 signer (no precompile) |
+| Compute Units | 150 | 12,441 | 8,983 | Session uses Ed25519 signer (no precompile) |
 | Transaction Size | 215 bytes | 658 bytes | 452 bytes | Session tx is smaller (no precompile ix) |
 | Instruction Data | 12 bytes | 254 bytes | 20 bytes | Session has no auth payload |
 | Accounts | 2 | 7 | 7 | Secp256r1 uses sysvar_instructions only |
@@ -53,9 +71,10 @@ The Secp256r1 Execute transaction was optimized from **708 bytes to 658 bytes** 
 | Transaction Fee | 0.000005 SOL | 0.000005 SOL | 0.000005 SOL | Same base fee |
 
 **Why the overhead is acceptable:**
-- 10,941 CU (Secp256r1) is only **5.5%** of the 200,000 CU default budget
-- 4,483 CU (Session) is only **2.2%** of the 200,000 CU default budget
+- 12,441 CU (Secp256r1) is only **6.2%** of the 200,000 CU default budget
+- 8,983 CU (Session) is only **4.5%** of the 200,000 CU default budget
 - 658 bytes (Secp256r1) is **53%** of the 1,232-byte transaction limit, leaving **574 bytes** for inner instructions
+- Deferred Execution provides ~1,100 bytes for inner instructions when needed (1.9x)
 - 452 bytes (Session) is only **37%** of the 1,232-byte limit
 - Transaction fee is identical (base fee is per-signature, not per-CU)
 - The overhead buys: passkey auth, RBAC, replay protection, session keys, multi-sig
@@ -74,10 +93,12 @@ Solana requires accounts to maintain a minimum balance (rent-exempt) based on da
 | Authority (Ed25519) | 80 | 0.001447680 | 1,447,680 |
 | Authority (Secp256r1) | ~125 | 0.001760880 | 1,760,880 |
 | Session | 80 | 0.001447680 | 1,447,680 |
+| DeferredExec | 176 | 0.002116320 | 2,116,320 |
 | Vault PDA | 0 | 0 | 0 |
 
 **Notes:**
 - Secp256r1 authority size is variable: 48 (header) + 32 (cred hash) + 33 (pubkey) + 1 (rpIdLen) + N (rpId). For `rpId = "example.com"` (11 bytes), total = 125 bytes.
+- **DeferredExec** rent is temporary -- refunded when ExecuteDeferred closes the account or when ReclaimDeferred reclaims an expired authorization.
 - **Vault PDA** is not initialized as a program-owned account. It simply receives SOL via transfer. No rent cost.
 
 ---
@@ -101,9 +122,11 @@ At $150/SOL, wallet creation costs approximately **$0.36 - $0.41 USD**.
 |---|---|
 | Execute (SOL transfer) | 0.000005 SOL (base fee only) |
 | Execute (token transfer) | 0.000005 SOL (base fee only) |
+| Deferred Execute (2 txs) | 0.00001 SOL (2x base fee) + 0.002116 SOL temp rent (refunded) |
 | Add Authority | 0.000005 SOL + authority rent |
 | Remove Authority | 0.000005 SOL (rent refunded) |
 | Create Session | 0.000005 SOL + session rent |
+| Reclaim Deferred | 0.000005 SOL (expired DeferredExec rent refunded) |
 
 **Key points:**
 - No per-transaction rent costs for Execute
@@ -138,6 +161,7 @@ At $150/SOL, session setup costs ~$0.22 USD. Each subsequent execute costs $0.00
 | Authority (Ed25519) | 48 bytes | 32 bytes (pubkey) | **80 bytes** |
 | Authority (Secp256r1) | 48 bytes | 32 (cred_hash) + 33 (pubkey) + 1 (rpIdLen) + N (rpId) | **114+ bytes** |
 | SessionAccount | 80 bytes | 0 | **80 bytes** |
+| DeferredExecAccount | 176 bytes | 0 | **176 bytes** |
 
 The compact data sizes are achieved through:
 - `#[repr(C, align(8))]` with `NoPadding` derive macro

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -4,7 +4,8 @@ use pinocchio::{
 };
 
 use crate::processor::{
-    create_session, create_wallet, execute, manage_authority, transfer_ownership,
+    authorize, create_session, create_wallet, execute, execute_deferred, manage_authority,
+    reclaim_deferred, transfer_ownership,
 };
 
 entrypoint!(process_instruction);
@@ -27,6 +28,9 @@ pub fn process_instruction(
         3 => transfer_ownership::process(program_id, accounts, data),
         4 => execute::process(program_id, accounts, data),
         5 => create_session::process(program_id, accounts, data),
+        6 => authorize::process(program_id, accounts, data),
+        7 => execute_deferred::process(program_id, accounts, data),
+        8 => reclaim_deferred::process(program_id, accounts, data),
         _ => Err(ProgramError::InvalidInstructionData),
     }
 }

--- a/program/src/error.rs
+++ b/program/src/error.rs
@@ -16,6 +16,11 @@ pub enum AuthError {
     InvalidAuthenticationKind = 3011,
     InvalidMessage = 3012,
     SelfReentrancyNotAllowed = 3013,
+    DeferredAuthorizationExpired = 3014,
+    DeferredHashMismatch = 3015,
+    InvalidExpiryWindow = 3016,
+    UnauthorizedReclaim = 3017,
+    DeferredAuthorizationNotExpired = 3018,
 }
 
 impl From<AuthError> for ProgramError {

--- a/program/src/processor/authorize.rs
+++ b/program/src/processor/authorize.rs
@@ -1,0 +1,218 @@
+use crate::{
+    auth::{secp256r1::Secp256r1Authenticator, traits::Authenticator},
+    error::AuthError,
+    state::{
+        authority::AuthorityAccountHeader,
+        deferred::DeferredExecAccount,
+        AccountDiscriminator, CURRENT_ACCOUNT_VERSION,
+    },
+    utils::initialize_pda_account,
+};
+use pinocchio::{
+    account_info::AccountInfo,
+    instruction::Seed,
+    program_error::ProgramError,
+    pubkey::{find_program_address, Pubkey},
+    sysvars::{clock::Clock, rent::Rent, Sysvar},
+    ProgramResult,
+};
+
+/// Minimum expiry window in slots (~4 seconds at 400ms/slot)
+const MIN_EXPIRY_SLOTS: u16 = 10;
+
+/// Maximum expiry window in slots (~1 hour at 400ms/slot)
+const MAX_EXPIRY_SLOTS: u16 = 9_000;
+
+/// Process the Authorize instruction (deferred execution tx1).
+///
+/// Verifies Secp256r1 signature over instruction/account hashes, then creates
+/// a DeferredExec PDA storing the authorization for later execution.
+///
+/// # Accounts:
+/// 1. `[signer, writable]` Payer
+/// 2. `[]` Wallet PDA
+/// 3. `[writable]` Authority PDA (counter increment)
+/// 4. `[writable]` DeferredExec PDA (created)
+/// 5. `[]` System Program
+/// 6. `[]` Rent Sysvar
+/// 7. `[]` Sysvar Instructions (for Secp256r1 precompile introspection)
+///
+/// # Instruction Data (after discriminator):
+///   [instructions_hash(32)][accounts_hash(32)][expiry_offset(2)][auth_payload(variable)]
+pub fn process(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    // Parse accounts
+    let payer = accounts
+        .first()
+        .ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let wallet_pda = accounts
+        .get(1)
+        .ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let authority_pda = accounts
+        .get(2)
+        .ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let deferred_pda = accounts
+        .get(3)
+        .ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let system_program = accounts
+        .get(4)
+        .ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let _rent_sysvar = accounts
+        .get(5)
+        .ok_or(ProgramError::NotEnoughAccountKeys)?;
+
+    // Validate payer is signer
+    if !payer.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    // Verify ownership
+    if wallet_pda.owner() != program_id || authority_pda.owner() != program_id {
+        return Err(ProgramError::IllegalOwner);
+    }
+
+    // Validate Wallet discriminator
+    let wallet_data = unsafe { wallet_pda.borrow_data_unchecked() };
+    if wallet_data.is_empty() || wallet_data[0] != AccountDiscriminator::Wallet as u8 {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    if !authority_pda.is_writable() {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    // Parse instruction data: [instructions_hash(32)][accounts_hash(32)][expiry_offset(2)][auth_payload(...)]
+    if instruction_data.len() < 66 {
+        // 32 + 32 + 2 minimum
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    let instructions_hash: [u8; 32] = instruction_data[0..32].try_into().unwrap();
+    let accounts_hash: [u8; 32] = instruction_data[32..64].try_into().unwrap();
+    let expiry_offset =
+        u16::from_le_bytes(instruction_data[64..66].try_into().unwrap());
+    let auth_payload = &instruction_data[66..];
+
+    // Validate expiry window
+    if expiry_offset < MIN_EXPIRY_SLOTS || expiry_offset > MAX_EXPIRY_SLOTS {
+        return Err(AuthError::InvalidExpiryWindow.into());
+    }
+
+    // Read authority header
+    let authority_data = unsafe { authority_pda.borrow_mut_data_unchecked() };
+    if authority_data.is_empty() || authority_data[0] != AccountDiscriminator::Authority as u8 {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    if authority_data.len() < std::mem::size_of::<AuthorityAccountHeader>() {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    let authority_header = unsafe {
+        std::ptr::read_unaligned(authority_data.as_ptr() as *const AuthorityAccountHeader)
+    };
+
+    if authority_header.wallet != *wallet_pda.key() {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    // Only Secp256r1 needs deferred execution
+    if authority_header.authority_type != 1 {
+        return Err(AuthError::InvalidAuthenticationKind.into());
+    }
+
+    // Only Owner or Admin can authorize (not Spender)
+    if authority_header.role > 1 {
+        return Err(AuthError::PermissionDenied.into());
+    }
+
+    // The signed_payload for Authorize is: instructions_hash || accounts_hash
+    let mut signed_payload = Vec::with_capacity(64);
+    signed_payload.extend_from_slice(&instructions_hash);
+    signed_payload.extend_from_slice(&accounts_hash);
+
+    // Authenticate — this verifies the Secp256r1 signature and increments the counter
+    Secp256r1Authenticator.authenticate(
+        accounts,
+        authority_data,
+        auth_payload,
+        &signed_payload,
+        &[6], // discriminator for Authorize
+        program_id,
+    )?;
+
+    // Read the counter value that was just committed
+    let updated_header = unsafe {
+        std::ptr::read_unaligned(authority_data.as_ptr() as *const AuthorityAccountHeader)
+    };
+    let counter_for_seed = updated_header.counter;
+
+    // Compute expiry
+    let clock = Clock::get()?;
+    let expires_at = clock.slot + expiry_offset as u64;
+
+    // Derive DeferredExec PDA
+    let counter_bytes = counter_for_seed.to_le_bytes();
+    let seeds: &[&[u8]] = &[
+        b"deferred",
+        wallet_pda.key().as_ref(),
+        authority_pda.key().as_ref(),
+        &counter_bytes,
+    ];
+    let (expected_pda, bump) = find_program_address(seeds, program_id);
+
+    if deferred_pda.key() != &expected_pda {
+        return Err(ProgramError::InvalidSeeds);
+    }
+
+    // Compute rent
+    let rent = Rent::get()?;
+    let space = std::mem::size_of::<DeferredExecAccount>();
+    let rent_lamports = rent.minimum_balance(space);
+
+    // Create DeferredExec PDA
+    let bump_arr = [bump];
+    let pda_seeds: &[Seed] = &[
+        Seed::from(b"deferred"),
+        Seed::from(wallet_pda.key().as_ref()),
+        Seed::from(authority_pda.key().as_ref()),
+        Seed::from(&counter_bytes),
+        Seed::from(&bump_arr),
+    ];
+
+    initialize_pda_account(
+        payer,
+        deferred_pda,
+        system_program,
+        space,
+        rent_lamports,
+        program_id,
+        pda_seeds,
+    )?;
+
+    // Write DeferredExec data
+    let deferred = DeferredExecAccount {
+        discriminator: AccountDiscriminator::DeferredExec as u8,
+        version: CURRENT_ACCOUNT_VERSION,
+        bump,
+        _padding: [0u8; 5],
+        instructions_hash,
+        accounts_hash,
+        wallet: *wallet_pda.key(),
+        authority: *authority_pda.key(),
+        payer: *payer.key(),
+        expires_at,
+    };
+
+    let deferred_data = unsafe { deferred_pda.borrow_mut_data_unchecked() };
+    unsafe {
+        std::ptr::write_unaligned(
+            deferred_data.as_mut_ptr() as *mut DeferredExecAccount,
+            deferred,
+        );
+    }
+
+    Ok(())
+}

--- a/program/src/processor/execute_deferred.rs
+++ b/program/src/processor/execute_deferred.rs
@@ -1,0 +1,252 @@
+use crate::{
+    compact::parse_compact_instructions,
+    error::AuthError,
+    state::{deferred::DeferredExecAccount, AccountDiscriminator},
+};
+use pinocchio::{
+    account_info::AccountInfo,
+    instruction::{Account, AccountMeta, Instruction, Seed, Signer},
+    program::invoke_signed_unchecked,
+    program_error::ProgramError,
+    pubkey::{find_program_address, Pubkey},
+    sysvars::{clock::Clock, Sysvar},
+    ProgramResult,
+};
+
+/// Process the ExecuteDeferred instruction (deferred execution tx2).
+///
+/// Verifies the compact instructions against the stored hash, executes them
+/// via CPI with vault PDA signing, then closes the DeferredExec account.
+///
+/// # Accounts:
+/// 1. `[signer, writable]` Payer
+/// 2. `[]` Wallet PDA
+/// 3. `[writable]` Vault PDA (signer for CPI)
+/// 4. `[writable]` DeferredExec PDA (read + closed)
+/// 5. `[writable]` Refund destination (receives rent refund)
+/// 6. `...` Inner accounts referenced by compact instructions
+///
+/// # Instruction Data (after discriminator):
+///   [compact_instructions(variable)]
+pub fn process(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+    // Parse accounts
+    let payer = accounts
+        .first()
+        .ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let wallet_pda = accounts
+        .get(1)
+        .ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let vault_pda = accounts
+        .get(2)
+        .ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let deferred_pda = accounts
+        .get(3)
+        .ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let refund_dest = accounts
+        .get(4)
+        .ok_or(ProgramError::NotEnoughAccountKeys)?;
+
+    // Validate payer
+    if !payer.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    // Verify ownership of wallet and deferred
+    if wallet_pda.owner() != program_id || deferred_pda.owner() != program_id {
+        return Err(ProgramError::IllegalOwner);
+    }
+
+    // Validate Wallet discriminator
+    let wallet_data = unsafe { wallet_pda.borrow_data_unchecked() };
+    if wallet_data.is_empty() || wallet_data[0] != AccountDiscriminator::Wallet as u8 {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    // Read DeferredExec account (read-only borrow for validation)
+    {
+        let deferred_check = unsafe { deferred_pda.borrow_data_unchecked() };
+        if deferred_check.len() < std::mem::size_of::<DeferredExecAccount>() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+    }
+
+    let deferred = unsafe {
+        let data = deferred_pda.borrow_data_unchecked();
+        std::ptr::read_unaligned(data.as_ptr() as *const DeferredExecAccount)
+    };
+
+    if deferred.discriminator != AccountDiscriminator::DeferredExec as u8 {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    // Verify wallet matches
+    if deferred.wallet != *wallet_pda.key() {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    // Verify refund destination matches stored payer
+    if deferred.payer != *refund_dest.key() {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    // Check expiry
+    let clock = Clock::get()?;
+    if clock.slot > deferred.expires_at {
+        return Err(AuthError::DeferredAuthorizationExpired.into());
+    }
+
+    // Parse compact instructions
+    let compact_instructions = parse_compact_instructions(instruction_data)?;
+
+    // Serialize compact instructions to compute hash
+    let compact_bytes = crate::compact::serialize_compact_instructions(&compact_instructions);
+
+    // Verify instructions hash
+    let instructions_hash = compute_sha256(&compact_bytes);
+    if instructions_hash != deferred.instructions_hash {
+        return Err(AuthError::DeferredHashMismatch.into());
+    }
+
+    // Verify accounts hash
+    let accounts_hash = compute_accounts_hash(accounts, &compact_instructions)?;
+    if accounts_hash != deferred.accounts_hash {
+        return Err(AuthError::DeferredHashMismatch.into());
+    }
+
+    // Derive vault PDA and verify
+    let (vault_key, vault_bump) =
+        find_program_address(&[b"vault", wallet_pda.key().as_ref()], program_id);
+
+    if vault_pda.key() != &vault_key {
+        return Err(ProgramError::InvalidSeeds);
+    }
+
+    // Close the DeferredExec account BEFORE CPI execution.
+    // All validation is complete — hashes verified, expiry checked.
+    // Closing before CPI avoids stale-pointer issues with invoke_signed_unchecked.
+    // If any CPI fails, the entire transaction reverts atomically.
+    let deferred_lamports = unsafe { *deferred_pda.borrow_mut_lamports_unchecked() };
+    let refund_lamports = unsafe { *refund_dest.borrow_mut_lamports_unchecked() };
+    unsafe {
+        *refund_dest.borrow_mut_lamports_unchecked() = refund_lamports
+            .checked_add(deferred_lamports)
+            .ok_or(ProgramError::ArithmeticOverflow)?;
+        *deferred_pda.borrow_mut_lamports_unchecked() = 0;
+    }
+    let close_data = unsafe { deferred_pda.borrow_mut_data_unchecked() };
+    close_data.fill(0);
+
+    // Execute each compact instruction via CPI with vault PDA signing
+    for compact_ix in &compact_instructions {
+        let decompressed = compact_ix.decompress(accounts)?;
+
+        // Build AccountMeta array
+        let account_metas: Vec<AccountMeta> = decompressed
+            .accounts
+            .iter()
+            .map(|acc| AccountMeta {
+                pubkey: acc.key(),
+                is_signer: acc.is_signer() || acc.key() == vault_pda.key(),
+                is_writable: acc.is_writable(),
+            })
+            .collect();
+
+        // Prevent self-reentrancy
+        if decompressed.program_id.as_ref() == program_id.as_ref() {
+            return Err(AuthError::SelfReentrancyNotAllowed.into());
+        }
+
+        let ix = Instruction {
+            program_id: decompressed.program_id,
+            accounts: &account_metas,
+            data: &decompressed.data,
+        };
+
+        let vault_bump_arr = [vault_bump];
+        let seeds = [
+            Seed::from(b"vault"),
+            Seed::from(wallet_pda.key().as_ref()),
+            Seed::from(&vault_bump_arr),
+        ];
+        let signer: Signer = (&seeds).into();
+
+        let cpi_accounts: Vec<Account> = decompressed
+            .accounts
+            .iter()
+            .map(|acc| Account::from(*acc))
+            .collect();
+
+        unsafe {
+            invoke_signed_unchecked(&ix, &cpi_accounts, &[signer]);
+        }
+    }
+
+    Ok(())
+}
+
+/// Compute SHA256 hash of bytes.
+fn compute_sha256(data: &[u8]) -> [u8; 32] {
+    #[allow(unused_assignments)]
+    let mut hash = [0u8; 32];
+    #[cfg(target_os = "solana")]
+    unsafe {
+        pinocchio::syscalls::sol_sha256(
+            [data].as_ptr() as *const u8,
+            1,
+            hash.as_mut_ptr(),
+        );
+    }
+    #[cfg(not(target_os = "solana"))]
+    {
+        hash = [0xAA; 32];
+        let _ = data;
+    }
+    hash
+}
+
+/// Compute SHA256 hash of all account pubkeys referenced by compact instructions.
+/// Same logic as execute.rs::compute_accounts_hash.
+fn compute_accounts_hash(
+    accounts: &[AccountInfo],
+    compact_instructions: &[crate::compact::CompactInstruction],
+) -> Result<[u8; 32], ProgramError> {
+    let mut pubkeys_data = Vec::new();
+
+    for ix in compact_instructions {
+        let program_idx = ix.program_id_index as usize;
+        if program_idx >= accounts.len() {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+        pubkeys_data.extend_from_slice(accounts[program_idx].key().as_ref());
+
+        for &acc_idx in &ix.accounts {
+            let idx = acc_idx as usize;
+            if idx >= accounts.len() {
+                return Err(ProgramError::InvalidInstructionData);
+            }
+            pubkeys_data.extend_from_slice(accounts[idx].key().as_ref());
+        }
+    }
+
+    #[allow(unused_assignments)]
+    let mut hash = [0u8; 32];
+    #[cfg(target_os = "solana")]
+    unsafe {
+        pinocchio::syscalls::sol_sha256(
+            [pubkeys_data.as_slice()].as_ptr() as *const u8,
+            1,
+            hash.as_mut_ptr(),
+        );
+    }
+    #[cfg(not(target_os = "solana"))]
+    {
+        hash = [0xAA; 32];
+        let _ = pubkeys_data;
+    }
+
+    Ok(hash)
+}

--- a/program/src/processor/mod.rs
+++ b/program/src/processor/mod.rs
@@ -2,8 +2,11 @@
 //!
 //! Each module corresponds to a specific instruction in the IDL.
 
+pub mod authorize;
 pub mod create_session;
 pub mod create_wallet;
 pub mod execute;
+pub mod execute_deferred;
 pub mod manage_authority;
+pub mod reclaim_deferred;
 pub mod transfer_ownership;

--- a/program/src/processor/reclaim_deferred.rs
+++ b/program/src/processor/reclaim_deferred.rs
@@ -1,0 +1,87 @@
+use crate::{
+    error::AuthError,
+    state::{deferred::DeferredExecAccount, AccountDiscriminator},
+};
+use pinocchio::{
+    account_info::AccountInfo,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    sysvars::{clock::Clock, Sysvar},
+    ProgramResult,
+};
+
+/// Process the ReclaimDeferred instruction.
+///
+/// Closes an expired DeferredExec account and refunds rent to the original payer.
+/// Only the original payer can reclaim, and only after the authorization has expired.
+///
+/// # Accounts:
+/// 1. `[signer]` Payer (must match stored payer)
+/// 2. `[writable]` DeferredExec PDA (closed)
+/// 3. `[writable]` Refund destination
+///
+/// # Instruction Data (after discriminator):
+///   (none)
+pub fn process(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    _instruction_data: &[u8],
+) -> ProgramResult {
+    let payer = accounts
+        .first()
+        .ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let deferred_pda = accounts
+        .get(1)
+        .ok_or(ProgramError::NotEnoughAccountKeys)?;
+    let refund_dest = accounts
+        .get(2)
+        .ok_or(ProgramError::NotEnoughAccountKeys)?;
+
+    // Validate signer
+    if !payer.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    // Verify ownership
+    if deferred_pda.owner() != program_id {
+        return Err(ProgramError::IllegalOwner);
+    }
+
+    // Read DeferredExec account
+    let deferred_data = unsafe { deferred_pda.borrow_mut_data_unchecked() };
+    if deferred_data.len() < std::mem::size_of::<DeferredExecAccount>() {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    let deferred = unsafe {
+        std::ptr::read_unaligned(deferred_data.as_ptr() as *const DeferredExecAccount)
+    };
+
+    if deferred.discriminator != AccountDiscriminator::DeferredExec as u8 {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    // Only the original payer can reclaim
+    if deferred.payer != *payer.key() {
+        return Err(AuthError::UnauthorizedReclaim.into());
+    }
+
+    // Can only reclaim after expiry
+    let clock = Clock::get()?;
+    if clock.slot <= deferred.expires_at {
+        return Err(AuthError::DeferredAuthorizationNotExpired.into());
+    }
+
+    // Close the account — zero data and drain lamports
+    for byte in deferred_data.iter_mut() {
+        *byte = 0;
+    }
+
+    let deferred_lamports = deferred_pda.lamports();
+    unsafe {
+        *deferred_pda.borrow_mut_lamports_unchecked() = 0;
+        *refund_dest.borrow_mut_lamports_unchecked() += deferred_lamports;
+    }
+
+    Ok(())
+}

--- a/program/src/state/deferred.rs
+++ b/program/src/state/deferred.rs
@@ -1,0 +1,36 @@
+use no_padding::NoPadding;
+use pinocchio::pubkey::Pubkey;
+
+/// Deferred Execution Authorization Account.
+///
+/// Created during the `Authorize` instruction (tx1) to store a pre-authorized
+/// set of instructions for later execution. The `ExecuteDeferred` instruction (tx2)
+/// verifies the hashes and executes the instructions, then closes this account.
+///
+/// This enables large payloads (e.g., Jupiter swaps) that exceed the ~574 bytes
+/// available in a single Secp256r1 Execute transaction.
+#[repr(C, align(8))]
+#[derive(NoPadding, Debug, Clone, Copy)]
+pub struct DeferredExecAccount {
+    /// Account discriminator (must be `4` for DeferredExec).
+    pub discriminator: u8,
+    /// Account version.
+    pub version: u8,
+    /// Bump seed for this PDA.
+    pub bump: u8,
+    /// Padding for alignment.
+    pub _padding: [u8; 5],
+    /// SHA256 of the serialized compact instructions bytes.
+    pub instructions_hash: [u8; 32],
+    /// SHA256 of all account pubkeys referenced by compact instructions.
+    pub accounts_hash: [u8; 32],
+    /// The wallet this authorization is for.
+    pub wallet: Pubkey,
+    /// The authority that created this authorization.
+    pub authority: Pubkey,
+    /// The payer who funded this account (receives rent refund on close).
+    pub payer: Pubkey,
+    /// Absolute slot at which this authorization expires.
+    pub expires_at: u64,
+}
+// Layout: 1+1+1+5+32+32+32+32+32+8 = 176 bytes

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -1,4 +1,5 @@
 pub mod authority;
+pub mod deferred;
 pub mod session;
 pub mod wallet;
 
@@ -11,6 +12,8 @@ pub enum AccountDiscriminator {
     Authority = 2,
     /// A Session account (Ephemeral Spender).
     Session = 3,
+    /// A Deferred Execution authorization account.
+    DeferredExec = 4,
 }
 
 /// Helper constant for versioning.

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -8,7 +8,7 @@ SDK_DIR="$ROOT_DIR/sdk/solita-client"
 
 if [ -z "$PROGRAM_ID" ]; then
     echo "Usage: $0 <new_program_id>"
-    echo "Example: $0 2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT"
+    echo "Example: $0 FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao"
     exit 1
 fi
 

--- a/sdk/solita-client/README.md
+++ b/sdk/solita-client/README.md
@@ -39,7 +39,7 @@ await sendAndConfirmTransaction(connection, tx, [payer]);
 ### PDA Helpers
 
 ```typescript
-import { findWalletPda, findVaultPda, findAuthorityPda, findSessionPda } from '@lazorkit/solita-client';
+import { findWalletPda, findVaultPda, findAuthorityPda, findSessionPda, findDeferredExecPda } from '@lazorkit/solita-client';
 
 // Derive wallet PDA from user seed
 const [walletPda, walletBump] = findWalletPda(userSeed);
@@ -52,6 +52,9 @@ const [authorityPda, authBump] = findAuthorityPda(walletPda, credentialIdHash);
 
 // Derive session PDA from wallet + session key
 const [sessionPda, sessionBump] = findSessionPda(walletPda, sessionKeyBytes);
+
+// Derive deferred execution PDA from wallet + authority + counter
+const [deferredPda, deferredBump] = findDeferredExecPda(walletPda, authorityPda, counter);
 ```
 
 ### Instruction Builders
@@ -66,6 +69,9 @@ import {
   createTransferOwnershipIx,
   createExecuteIx,
   createCreateSessionIx,
+  createAuthorizeIx,
+  createExecuteDeferredIx,
+  createReclaimDeferredIx,
 } from '@lazorkit/solita-client';
 ```
 
@@ -100,12 +106,51 @@ const ix = createExecuteIx({
 });
 ```
 
+#### createAuthorizeIx (Deferred Execution TX1)
+
+```typescript
+const ix = createAuthorizeIx({
+  payer: PublicKey,
+  walletPda: PublicKey,
+  authorityPda: PublicKey,
+  deferredExecPda: PublicKey,
+  instructionsHash: Uint8Array,  // 32 bytes — SHA256 of packed compact instructions
+  accountsHash: Uint8Array,      // 32 bytes — SHA256 of all referenced account pubkeys
+  expiryOffset: number,          // Slots until expiry (10-9000)
+  authPayload: Uint8Array,       // Secp256r1 auth payload
+});
+```
+
+#### createExecuteDeferredIx (Deferred Execution TX2)
+
+```typescript
+const ix = createExecuteDeferredIx({
+  payer: PublicKey,
+  walletPda: PublicKey,
+  vaultPda: PublicKey,
+  deferredExecPda: PublicKey,
+  refundDestination: PublicKey,
+  packedInstructions: Uint8Array,   // From packCompactInstructions()
+  remainingAccounts?: AccountMeta[], // Inner accounts referenced by instructions
+});
+```
+
+#### createReclaimDeferredIx
+
+```typescript
+const ix = createReclaimDeferredIx({
+  payer: PublicKey,
+  deferredExecPda: PublicKey,
+  refundDestination: PublicKey,
+});
+```
+
 ### Compact Instruction Packing
 
 Pack multiple instructions for Execute:
 
 ```typescript
-import { packCompactInstructions, computeAccountsHash } from '@lazorkit/solita-client';
+import { packCompactInstructions, computeAccountsHash, computeInstructionsHash } from '@lazorkit/solita-client';
 
 // Define compact instructions with account indexes (not pubkeys)
 const packed = packCompactInstructions([{
@@ -116,6 +161,9 @@ const packed = packCompactInstructions([{
 
 // For Secp256r1: compute accounts hash for signature binding
 const accountsHash = computeAccountsHash(accountMetas, compactInstructions);
+
+// For deferred execution: compute instructions hash (signed in TX1, verified in TX2)
+const instructionsHash = computeInstructionsHash(compactInstructions);
 ```
 
 ### Secp256r1 (Passkey) Utilities
@@ -198,6 +246,25 @@ const { ix, precompileIx } = await client.executeSecp256r1({
   signer, slot, sysvarIxIndex,
   compactInstructions, remainingAccounts,
 });
+
+// Deferred Execution — TX1 (Authorize)
+const { ix, precompileIx, deferredExecPda } = await client.authorizeSecp256r1({
+  payer, walletPda, authorityPda,
+  signer, slot, sysvarIxIndex,
+  compactInstructions, accountMetas,
+  expiryOffset: 300, // ~2 minutes
+});
+
+// Deferred Execution — TX2 (ExecuteDeferred)
+const ix = client.executeDeferredSecp256r1({
+  payer, walletPda, vaultPda, deferredExecPda,
+  refundDestination, packedInstructions, remainingAccounts,
+});
+
+// Reclaim expired DeferredExec (refund rent)
+const ix = client.reclaimDeferred({
+  payer, deferredExecPda, refundDestination,
+});
 ```
 
 ### Constants
@@ -210,6 +277,9 @@ DISC_REMOVE_AUTHORITY // 2
 DISC_TRANSFER_OWNERSHIP // 3
 DISC_EXECUTE          // 4
 DISC_CREATE_SESSION   // 5
+DISC_AUTHORIZE        // 6
+DISC_EXECUTE_DEFERRED // 7
+DISC_RECLAIM_DEFERRED // 8
 
 // Auth types
 AUTH_TYPE_ED25519     // 0
@@ -221,7 +291,7 @@ ROLE_ADMIN   // 1
 ROLE_SPENDER // 2
 
 // Program ID
-PROGRAM_ID   // 2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT
+PROGRAM_ID   // FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao
 ```
 
 ### Error Handling
@@ -255,6 +325,11 @@ Error codes:
 | 3011 | InvalidAuthenticationKind | Unknown authority_type |
 | 3012 | InvalidMessage | N/A |
 | 3013 | SelfReentrancyNotAllowed | CPI back into program rejected |
+| 3014 | DeferredAuthorizationExpired | DeferredExec past expires_at slot |
+| 3015 | DeferredHashMismatch | Instructions or accounts hash mismatch |
+| 3016 | InvalidExpiryWindow | Expiry offset out of range (10-9000 slots) |
+| 3017 | UnauthorizedReclaim | Only original payer can reclaim |
+| 3018 | DeferredAuthorizationNotExpired | Cannot reclaim before expiry |
 
 ### Generated Accounts
 
@@ -274,7 +349,7 @@ After modifying program instructions:
 
 ```bash
 # 1. Regenerate IDL
-cd program && shank idl -o . --out-filename idl.json -p 2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT
+cd program && shank idl -o . --out-filename idl.json -p FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao
 
 # 2. Regenerate SDK
 cd sdk/solita-client && node generate.mjs

--- a/sdk/solita-client/generate.mjs
+++ b/sdk/solita-client/generate.mjs
@@ -20,7 +20,7 @@ console.log('Read IDL from', idlPath);
 
 // ─── 2. Inject program address ──────────────────────────────────
 idl.metadata = idl.metadata || {};
-idl.metadata.address = '2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT';
+idl.metadata.address = 'FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao';
 
 // ─── 3. Add account types ───────────────────────────────────────
 idl.accounts = [

--- a/sdk/solita-client/idl-enriched.json
+++ b/sdk/solita-client/idl-enriched.json
@@ -438,7 +438,7 @@
   ],
   "metadata": {
     "origin": "shank",
-    "address": "2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT"
+    "address": "FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao"
   },
   "accounts": [
     {

--- a/sdk/solita-client/src/generated/accounts/AuthorityAccount.ts
+++ b/sdk/solita-client/src/generated/accounts/AuthorityAccount.ts
@@ -100,7 +100,7 @@ export class AuthorityAccount implements AuthorityAccountArgs {
    *
    * @param programId - the program that owns the accounts we are filtering
    */
-  static gpaBuilder(programId: web3.PublicKey = new web3.PublicKey('2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT')) {
+  static gpaBuilder(programId: web3.PublicKey = new web3.PublicKey('FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao')) {
     return beetSolana.GpaBuilder.fromStruct(programId, authorityAccountBeet)
   }
 

--- a/sdk/solita-client/src/generated/accounts/SessionAccount.ts
+++ b/sdk/solita-client/src/generated/accounts/SessionAccount.ts
@@ -97,7 +97,7 @@ export class SessionAccount implements SessionAccountArgs {
    *
    * @param programId - the program that owns the accounts we are filtering
    */
-  static gpaBuilder(programId: web3.PublicKey = new web3.PublicKey('2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT')) {
+  static gpaBuilder(programId: web3.PublicKey = new web3.PublicKey('FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao')) {
     return beetSolana.GpaBuilder.fromStruct(programId, sessionAccountBeet)
   }
 

--- a/sdk/solita-client/src/generated/accounts/WalletAccount.ts
+++ b/sdk/solita-client/src/generated/accounts/WalletAccount.ts
@@ -88,7 +88,7 @@ export class WalletAccount implements WalletAccountArgs {
    *
    * @param programId - the program that owns the accounts we are filtering
    */
-  static gpaBuilder(programId: web3.PublicKey = new web3.PublicKey('2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT')) {
+  static gpaBuilder(programId: web3.PublicKey = new web3.PublicKey('FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao')) {
     return beetSolana.GpaBuilder.fromStruct(programId, walletAccountBeet)
   }
 

--- a/sdk/solita-client/src/generated/index.ts
+++ b/sdk/solita-client/src/generated/index.ts
@@ -10,7 +10,7 @@ export * from './types';
  * @category constants
  * @category generated
  */
-export const PROGRAM_ADDRESS = '2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT'
+export const PROGRAM_ADDRESS = 'FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao'
 
 /**
  * Program public key

--- a/sdk/solita-client/src/generated/instructions/AddAuthority.ts
+++ b/sdk/solita-client/src/generated/instructions/AddAuthority.ts
@@ -77,7 +77,7 @@ export const AddAuthorityStruct = new beet.BeetArgsStruct<AddAuthorityInstructio
      */
     export function createAddAuthorityInstruction(
       accounts: AddAuthorityInstructionAccounts, 
-args: AddAuthorityInstructionArgs , programId = new web3.PublicKey('2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT')
+args: AddAuthorityInstructionArgs , programId = new web3.PublicKey('FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao')
     ) {
       const [data] = AddAuthorityStruct.serialize({
         instructionDiscriminator: addAuthorityInstructionDiscriminator,

--- a/sdk/solita-client/src/generated/instructions/CreateSession.ts
+++ b/sdk/solita-client/src/generated/instructions/CreateSession.ts
@@ -73,7 +73,7 @@ export const CreateSessionStruct = new beet.BeetArgsStruct<CreateSessionInstruct
      */
     export function createCreateSessionInstruction(
       accounts: CreateSessionInstructionAccounts, 
-args: CreateSessionInstructionArgs , programId = new web3.PublicKey('2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT')
+args: CreateSessionInstructionArgs , programId = new web3.PublicKey('FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao')
     ) {
       const [data] = CreateSessionStruct.serialize({
         instructionDiscriminator: createSessionInstructionDiscriminator,

--- a/sdk/solita-client/src/generated/instructions/CreateWallet.ts
+++ b/sdk/solita-client/src/generated/instructions/CreateWallet.ts
@@ -72,7 +72,7 @@ export const CreateWalletStruct = new beet.FixableBeetArgsStruct<CreateWalletIns
      */
     export function createCreateWalletInstruction(
       accounts: CreateWalletInstructionAccounts, 
-args: CreateWalletInstructionArgs , programId = new web3.PublicKey('2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT')
+args: CreateWalletInstructionArgs , programId = new web3.PublicKey('FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao')
     ) {
       const [data] = CreateWalletStruct.serialize({
         instructionDiscriminator: createWalletInstructionDiscriminator,

--- a/sdk/solita-client/src/generated/instructions/Execute.ts
+++ b/sdk/solita-client/src/generated/instructions/Execute.ts
@@ -70,7 +70,7 @@ export const ExecuteStruct = new beet.FixableBeetArgsStruct<ExecuteInstructionAr
      */
     export function createExecuteInstruction(
       accounts: ExecuteInstructionAccounts, 
-args: ExecuteInstructionArgs , programId = new web3.PublicKey('2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT')
+args: ExecuteInstructionArgs , programId = new web3.PublicKey('FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao')
     ) {
       const [data] = ExecuteStruct.serialize({
         instructionDiscriminator: executeInstructionDiscriminator,

--- a/sdk/solita-client/src/generated/instructions/RemoveAuthority.ts
+++ b/sdk/solita-client/src/generated/instructions/RemoveAuthority.ts
@@ -60,7 +60,7 @@ export const RemoveAuthorityStruct = new beet.BeetArgsStruct<{ instructionDiscri
      */
     export function createRemoveAuthorityInstruction(
       accounts: RemoveAuthorityInstructionAccounts, 
-programId = new web3.PublicKey('2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT')
+programId = new web3.PublicKey('FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao')
     ) {
       const [data] = RemoveAuthorityStruct.serialize({
         instructionDiscriminator: removeAuthorityInstructionDiscriminator,

--- a/sdk/solita-client/src/generated/instructions/TransferOwnership.ts
+++ b/sdk/solita-client/src/generated/instructions/TransferOwnership.ts
@@ -75,7 +75,7 @@ export const TransferOwnershipStruct = new beet.BeetArgsStruct<TransferOwnership
      */
     export function createTransferOwnershipInstruction(
       accounts: TransferOwnershipInstructionAccounts, 
-args: TransferOwnershipInstructionArgs , programId = new web3.PublicKey('2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT')
+args: TransferOwnershipInstructionArgs , programId = new web3.PublicKey('FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao')
     ) {
       const [data] = TransferOwnershipStruct.serialize({
         instructionDiscriminator: transferOwnershipInstructionDiscriminator,

--- a/sdk/solita-client/src/utils/instructions.ts
+++ b/sdk/solita-client/src/utils/instructions.ts
@@ -19,6 +19,9 @@ export const DISC_REMOVE_AUTHORITY = 2;
 export const DISC_TRANSFER_OWNERSHIP = 3;
 export const DISC_EXECUTE = 4;
 export const DISC_CREATE_SESSION = 5;
+export const DISC_AUTHORIZE = 6;
+export const DISC_EXECUTE_DEFERRED = 7;
+export const DISC_RECLAIM_DEFERRED = 8;
 
 // ─── Authority types ─────────────────────────────────────────────────
 export const AUTH_TYPE_ED25519 = 0;
@@ -356,6 +359,114 @@ export function createCreateSessionIx(params: {
     programId: pid,
     keys,
     data: Buffer.from(concatBytes(parts)),
+  });
+}
+
+// ─── Authorize (Deferred Execution tx1) ─────────────────────────────
+/**
+ * Instruction data layout (after discriminator):
+ *   [instructions_hash(32)][accounts_hash(32)][expiry_offset(2)][auth_payload(variable)]
+ */
+export function createAuthorizeIx(params: {
+  payer: PublicKey;
+  walletPda: PublicKey;
+  authorityPda: PublicKey;
+  deferredExecPda: PublicKey;
+  instructionsHash: Uint8Array;
+  accountsHash: Uint8Array;
+  expiryOffset: number;
+  authPayload: Uint8Array;
+  programId?: PublicKey;
+}): TransactionInstruction {
+  const pid = params.programId ?? PROGRAM_ID;
+  const expiryBuf = Buffer.alloc(2);
+  expiryBuf.writeUInt16LE(params.expiryOffset);
+
+  const parts: Uint8Array[] = [
+    new Uint8Array([DISC_AUTHORIZE]),
+    params.instructionsHash,
+    params.accountsHash,
+    new Uint8Array(expiryBuf),
+    params.authPayload,
+  ];
+
+  return new TransactionInstruction({
+    programId: pid,
+    keys: [
+      { pubkey: params.payer, isSigner: true, isWritable: true },
+      { pubkey: params.walletPda, isSigner: false, isWritable: false },
+      { pubkey: params.authorityPda, isSigner: false, isWritable: true },
+      { pubkey: params.deferredExecPda, isSigner: false, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      { pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false },
+      { pubkey: SYSVAR_INSTRUCTIONS_PUBKEY, isSigner: false, isWritable: false },
+    ],
+    data: Buffer.from(concatBytes(parts)),
+  });
+}
+
+// ─── ExecuteDeferred (Deferred Execution tx2) ───────────────────────
+/**
+ * Instruction data layout (after discriminator):
+ *   [compact_instructions(variable)]
+ */
+export function createExecuteDeferredIx(params: {
+  payer: PublicKey;
+  walletPda: PublicKey;
+  vaultPda: PublicKey;
+  deferredExecPda: PublicKey;
+  refundDestination: PublicKey;
+  packedInstructions: Uint8Array;
+  /** Additional account metas for the inner CPI instructions */
+  remainingAccounts?: { pubkey: PublicKey; isSigner: boolean; isWritable: boolean }[];
+  programId?: PublicKey;
+}): TransactionInstruction {
+  const pid = params.programId ?? PROGRAM_ID;
+  const parts: Uint8Array[] = [
+    new Uint8Array([DISC_EXECUTE_DEFERRED]),
+    params.packedInstructions,
+  ];
+
+  const keys = [
+    { pubkey: params.payer, isSigner: true, isWritable: true },
+    { pubkey: params.walletPda, isSigner: false, isWritable: false },
+    { pubkey: params.vaultPda, isSigner: false, isWritable: true },
+    { pubkey: params.deferredExecPda, isSigner: false, isWritable: true },
+    { pubkey: params.refundDestination, isSigner: false, isWritable: true },
+  ];
+
+  if (params.remainingAccounts) {
+    keys.push(...params.remainingAccounts);
+  }
+
+  return new TransactionInstruction({
+    programId: pid,
+    keys,
+    data: Buffer.from(concatBytes(parts)),
+  });
+}
+
+// ─── ReclaimDeferred ────────────────────────────────────────────────
+/**
+ * Closes an expired DeferredExec account and refunds rent.
+ * Instruction data: discriminator only (no payload).
+ */
+export function createReclaimDeferredIx(params: {
+  payer: PublicKey;
+  deferredExecPda: PublicKey;
+  refundDestination: PublicKey;
+  programId?: PublicKey;
+}): TransactionInstruction {
+  const pid = params.programId ?? PROGRAM_ID;
+
+  return new TransactionInstruction({
+    programId: pid,
+    keys: [
+      { pubkey: params.payer, isSigner: true, isWritable: false },
+      { pubkey: params.deferredExecPda, isSigner: false, isWritable: true },
+      { pubkey: params.refundDestination, isSigner: false, isWritable: true },
+    ],
+    data: Buffer.from([DISC_RECLAIM_DEFERRED]),
   });
 }
 

--- a/sdk/solita-client/src/utils/packing.ts
+++ b/sdk/solita-client/src/utils/packing.ts
@@ -54,6 +54,17 @@ export function computeAccountsHash(
   return new Uint8Array(createHash('sha256').update(data).digest());
 }
 
+/**
+ * Computes the SHA-256 hash of packed compact instructions.
+ * Used for deferred execution — the hash is signed in tx1 and verified in tx2.
+ */
+export function computeInstructionsHash(
+  instructions: CompactInstruction[],
+): Uint8Array {
+  const packed = packCompactInstructions(instructions);
+  return new Uint8Array(createHash('sha256').update(packed).digest());
+}
+
 function concatBytes(arrays: Uint8Array[]): Uint8Array {
   const totalLen = arrays.reduce((s, a) => s + a.length, 0);
   const out = new Uint8Array(totalLen);

--- a/sdk/solita-client/src/utils/pdas.ts
+++ b/sdk/solita-client/src/utils/pdas.ts
@@ -42,3 +42,22 @@ export function findSessionPda(
     programId,
   );
 }
+
+export function findDeferredExecPda(
+  walletPda: PublicKey,
+  authorityPda: PublicKey,
+  counter: number,
+  programId: PublicKey = PROGRAM_ID,
+): [PublicKey, number] {
+  const counterBuf = Buffer.alloc(4);
+  counterBuf.writeUInt32LE(counter);
+  return PublicKey.findProgramAddressSync(
+    [
+      Buffer.from('deferred'),
+      walletPda.toBuffer(),
+      authorityPda.toBuffer(),
+      counterBuf,
+    ],
+    programId,
+  );
+}

--- a/sdk/solita-client/src/utils/wrapper.ts
+++ b/sdk/solita-client/src/utils/wrapper.ts
@@ -5,7 +5,7 @@ import {
 } from '@solana/web3.js';
 import { PROGRAM_ID } from '../generated';
 import { AuthorityAccount } from '../generated/accounts';
-import { findWalletPda, findVaultPda, findAuthorityPda, findSessionPda } from './pdas';
+import { findWalletPda, findVaultPda, findAuthorityPda, findSessionPda, findDeferredExecPda } from './pdas';
 import {
   readAuthorityCounter,
   buildAuthPayload,
@@ -13,7 +13,7 @@ import {
   type Secp256r1Signer,
 } from './secp256r1';
 import type { Ed25519Signer } from './ed25519';
-import { packCompactInstructions, computeAccountsHash, type CompactInstruction } from './packing';
+import { packCompactInstructions, computeAccountsHash, computeInstructionsHash, type CompactInstruction } from './packing';
 import {
   createCreateWalletIx,
   createAddAuthorityIx,
@@ -28,6 +28,10 @@ import {
   DISC_TRANSFER_OWNERSHIP,
   DISC_EXECUTE,
   DISC_CREATE_SESSION,
+  DISC_AUTHORIZE,
+  createAuthorizeIx,
+  createExecuteDeferredIx,
+  createReclaimDeferredIx,
 } from './instructions';
 
 export class LazorKitClient {
@@ -44,6 +48,9 @@ export class LazorKitClient {
   }
   findSession(walletPda: PublicKey, sessionKey: Uint8Array) {
     return findSessionPda(walletPda, sessionKey, this.programId);
+  }
+  findDeferredExec(walletPda: PublicKey, authorityPda: PublicKey, counter: number) {
+    return findDeferredExecPda(walletPda, authorityPda, counter, this.programId);
   }
 
   // ─── Account readers ─────────────────────────────────────────────
@@ -335,6 +342,126 @@ export class LazorKitClient {
     });
 
     return { ix, sessionPda };
+  }
+
+  // ─── Authorize (Deferred Execution tx1, Secp256r1) ───────────────
+  async authorizeSecp256r1(params: {
+    payer: PublicKey;
+    walletPda: PublicKey;
+    authorityPda: PublicKey;
+    signer: Secp256r1Signer;
+    slot: bigint;
+    sysvarIxIndex: number;
+    compactInstructions: CompactInstruction[];
+    /** Account metas for the tx2 (ExecuteDeferred) layout */
+    tx2AccountMetas: { pubkey: PublicKey; isSigner: boolean; isWritable: boolean }[];
+    /** Expiry offset in slots (default 300 = ~2 minutes) */
+    expiryOffset?: number;
+  }): Promise<{
+    authorizeIx: TransactionInstruction;
+    precompileIx: TransactionInstruction;
+    deferredExecPda: PublicKey;
+    counter: number;
+  }> {
+    const counter = (await this.readCounter(params.authorityPda)) + 1;
+    const expiryOffset = params.expiryOffset ?? 300;
+
+    // Compute instruction hash and accounts hash for tx2
+    const instructionsHash = computeInstructionsHash(params.compactInstructions);
+    const accountsHash = computeAccountsHash(params.tx2AccountMetas, params.compactInstructions);
+
+    // signed_payload = instructions_hash || accounts_hash
+    const signedPayload = new Uint8Array(64);
+    signedPayload.set(instructionsHash, 0);
+    signedPayload.set(accountsHash, 32);
+
+    // Build challenge hash
+    const challenge = buildSecp256r1Challenge({
+      discriminator: new Uint8Array([DISC_AUTHORIZE]),
+      authPayload: new Uint8Array(0),
+      signedPayload,
+      slot: params.slot,
+      payer: params.payer,
+      counter,
+      programId: this.programId,
+    });
+
+    // Sign
+    const { signature, authenticatorData } = await params.signer.sign(challenge);
+
+    // Build auth payload
+    const authPayload = buildAuthPayload({
+      slot: params.slot,
+      counter,
+      sysvarIxIndex: params.sysvarIxIndex,
+      typeAndFlags: 0,
+      authenticatorData,
+    });
+
+    // Build precompile instruction
+    const precompileIx = buildSecp256r1PrecompileIx(
+      params.signer.publicKeyBytes,
+      challenge,
+      signature,
+    );
+
+    // Derive DeferredExec PDA using the counter value
+    const [deferredExecPda] = this.findDeferredExec(
+      params.walletPda,
+      params.authorityPda,
+      counter,
+    );
+
+    const authorizeIx = createAuthorizeIx({
+      payer: params.payer,
+      walletPda: params.walletPda,
+      authorityPda: params.authorityPda,
+      deferredExecPda,
+      instructionsHash,
+      accountsHash,
+      expiryOffset,
+      authPayload,
+      programId: this.programId,
+    });
+
+    return { authorizeIx, precompileIx, deferredExecPda, counter };
+  }
+
+  // ─── ExecuteDeferred (Deferred Execution tx2) ───────────────────
+  executeDeferredSecp256r1(params: {
+    payer: PublicKey;
+    walletPda: PublicKey;
+    vaultPda: PublicKey;
+    deferredExecPda: PublicKey;
+    refundDestination: PublicKey;
+    compactInstructions: CompactInstruction[];
+    remainingAccounts?: { pubkey: PublicKey; isSigner: boolean; isWritable: boolean }[];
+  }): TransactionInstruction {
+    const packed = packCompactInstructions(params.compactInstructions);
+    return createExecuteDeferredIx({
+      payer: params.payer,
+      walletPda: params.walletPda,
+      vaultPda: params.vaultPda,
+      deferredExecPda: params.deferredExecPda,
+      refundDestination: params.refundDestination,
+      packedInstructions: packed,
+      remainingAccounts: params.remainingAccounts,
+      programId: this.programId,
+    });
+  }
+
+  // ─── ReclaimDeferred ────────────────────────────────────────────
+  reclaimDeferred(params: {
+    payer: PublicKey;
+    deferredExecPda: PublicKey;
+    refundDestination: PublicKey;
+  }): TransactionInstruction {
+    return createReclaimDeferredIx({
+      payer: params.payer,
+      deferredExecPda: params.deferredExecPda,
+      refundDestination: params.refundDestination,
+      programId: this.programId,
+    });
   }
 
   // ─── TransferOwnership (Ed25519) ─────────────────────────────────

--- a/tests-sdk/package.json
+++ b/tests-sdk/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "vitest run --fileParallelism=false",
     "test:watch": "vitest --fileParallelism=false",
-    "validator:start": "solana-test-validator --bpf-program 2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT ../target/deploy/lazorkit_program.so --reset",
+    "validator:start": "solana-test-validator --bpf-program FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao ../target/deploy/lazorkit_program.so --reset",
     "benchmark": "npx tsx tests/benchmark.ts",
     "pretest": "echo 'Ensure solana-test-validator is running with the program loaded'"
   },

--- a/tests-sdk/tests/08-deferred.test.ts
+++ b/tests-sdk/tests/08-deferred.test.ts
@@ -1,0 +1,639 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import {
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+import * as crypto from 'crypto';
+import { setupTest, sendTx, sendTxExpectError, getSlot, type TestContext } from './common';
+import { generateMockSecp256r1Key, signSecp256r1 } from './secp256r1Utils';
+import {
+  findWalletPda,
+  findVaultPda,
+  findAuthorityPda,
+  findDeferredExecPda,
+  createCreateWalletIx,
+  createAuthorizeIx,
+  createExecuteDeferredIx,
+  createReclaimDeferredIx,
+  packCompactInstructions,
+  computeAccountsHash,
+  computeInstructionsHash,
+  buildAuthPayload,
+  buildSecp256r1Challenge,
+  AUTH_TYPE_SECP256R1,
+  DISC_AUTHORIZE,
+  PROGRAM_ID,
+} from '../../sdk/solita-client/src';
+
+describe('Deferred Execution', () => {
+  let ctx: TestContext;
+
+  beforeAll(async () => {
+    ctx = await setupTest();
+  });
+
+  describe('Happy Path', () => {
+    let walletPda: PublicKey;
+    let vaultPda: PublicKey;
+    let ownerKey: Awaited<ReturnType<typeof generateMockSecp256r1Key>>;
+    let ownerAuthorityPda: PublicKey;
+
+    beforeAll(async () => {
+      ownerKey = await generateMockSecp256r1Key();
+      const userSeed = crypto.randomBytes(32);
+
+      [walletPda] = findWalletPda(userSeed);
+      [vaultPda] = findVaultPda(walletPda);
+      const [authPda, authBump] = findAuthorityPda(walletPda, ownerKey.credentialIdHash);
+      ownerAuthorityPda = authPda;
+
+      await sendTx(ctx, [createCreateWalletIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        vaultPda,
+        authorityPda: authPda,
+        userSeed,
+        authType: AUTH_TYPE_SECP256R1,
+        authBump,
+        credentialOrPubkey: ownerKey.credentialIdHash,
+        secp256r1Pubkey: ownerKey.publicKeyBytes,
+        rpId: ownerKey.rpId,
+      })]);
+
+      // Fund the vault
+      const sig = await ctx.connection.requestAirdrop(vaultPda, 5 * LAMPORTS_PER_SOL);
+      await ctx.connection.confirmTransaction(sig, 'confirmed');
+    });
+
+    it('authorizes and executes a single SOL transfer via deferred', async () => {
+      const recipient = Keypair.generate().publicKey;
+      const slot = await getSlot(ctx);
+
+      // Build a SOL transfer as compact instruction
+      const transferData = Buffer.alloc(12);
+      transferData.writeUInt32LE(2, 0); // System Transfer
+      transferData.writeBigUInt64LE(BigInt(LAMPORTS_PER_SOL), 4);
+
+      // Compact instruction indices are relative to tx2 account layout:
+      //   0: payer, 1: wallet, 2: vault, 3: deferred, 4: refundDest
+      //   5: SystemProgram, 6: recipient
+      const compactIxs = [{
+        programIdIndex: 5,
+        accountIndexes: [2, 6], // vault (from), recipient (to)
+        data: new Uint8Array(transferData),
+      }];
+
+      // Compute hashes
+      const instructionsHash = computeInstructionsHash(compactIxs);
+      const tx2AccountMetas = [
+        { pubkey: ctx.payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: walletPda, isSigner: false, isWritable: false },
+        { pubkey: vaultPda, isSigner: false, isWritable: true },
+        { pubkey: PublicKey.default, isSigner: false, isWritable: true }, // deferred placeholder
+        { pubkey: ctx.payer.publicKey, isSigner: false, isWritable: true }, // refund dest
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+        { pubkey: recipient, isSigner: false, isWritable: true },
+      ];
+      const accountsHash = computeAccountsHash(tx2AccountMetas, compactIxs);
+
+      // Build signed_payload = instructions_hash || accounts_hash
+      const signedPayload = Buffer.concat([instructionsHash, accountsHash]);
+
+      // Sign with Secp256r1
+      const { authPayload, precompileIx } = await signSecp256r1({
+        key: ownerKey,
+        discriminator: new Uint8Array([DISC_AUTHORIZE]),
+        signedPayload,
+        slot,
+        counter: 1,
+        payer: ctx.payer.publicKey,
+        sysvarIxIndex: 6, // index 6 in Authorize tx accounts
+      });
+
+      // Derive deferred PDA (counter = 1)
+      const [deferredExecPda] = findDeferredExecPda(walletPda, ownerAuthorityPda, 1);
+
+      // === TX1: Authorize ===
+      const authorizeIx = createAuthorizeIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        authorityPda: ownerAuthorityPda,
+        deferredExecPda,
+        instructionsHash,
+        accountsHash,
+        expiryOffset: 300,
+        authPayload,
+      });
+
+      await sendTx(ctx, [precompileIx, authorizeIx]);
+
+      // Verify DeferredExec account was created
+      const deferredAccount = await ctx.connection.getAccountInfo(deferredExecPda);
+      expect(deferredAccount).not.toBeNull();
+      expect(deferredAccount!.data.length).toBe(176);
+      expect(deferredAccount!.data[0]).toBe(4); // DeferredExec discriminator
+
+      // === TX2: ExecuteDeferred ===
+      const packed = packCompactInstructions(compactIxs);
+      const executeDeferredIx = createExecuteDeferredIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        vaultPda,
+        deferredExecPda,
+        refundDestination: ctx.payer.publicKey,
+        packedInstructions: packed,
+        remainingAccounts: [
+          { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+          { pubkey: recipient, isSigner: false, isWritable: true },
+        ],
+      });
+
+      const balanceBefore = await ctx.connection.getBalance(recipient);
+      await sendTx(ctx, [executeDeferredIx]);
+      const balanceAfter = await ctx.connection.getBalance(recipient);
+
+      expect(balanceAfter - balanceBefore).toBe(LAMPORTS_PER_SOL);
+
+      // Verify DeferredExec account was closed
+      const deferredAfter = await ctx.connection.getAccountInfo(deferredExecPda);
+      expect(deferredAfter).toBeNull();
+    });
+
+    it('authorizes and executes multiple SOL transfers via deferred', async () => {
+      const recipient1 = Keypair.generate().publicKey;
+      const recipient2 = Keypair.generate().publicKey;
+      const recipient3 = Keypair.generate().publicKey;
+      const slot = await getSlot(ctx);
+
+      // 3 SOL transfers — simulates a complex multi-instruction payload
+      const makeTransferData = (amount: bigint) => {
+        const buf = Buffer.alloc(12);
+        buf.writeUInt32LE(2, 0);
+        buf.writeBigUInt64LE(amount, 4);
+        return new Uint8Array(buf);
+      };
+
+      // tx2 layout:
+      //   0: payer, 1: wallet, 2: vault, 3: deferred, 4: refundDest
+      //   5: SystemProgram, 6: recipient1, 7: recipient2, 8: recipient3
+      const compactIxs = [
+        { programIdIndex: 5, accountIndexes: [2, 6], data: makeTransferData(BigInt(LAMPORTS_PER_SOL)) },
+        { programIdIndex: 5, accountIndexes: [2, 7], data: makeTransferData(BigInt(LAMPORTS_PER_SOL)) },
+        { programIdIndex: 5, accountIndexes: [2, 8], data: makeTransferData(BigInt(LAMPORTS_PER_SOL)) },
+      ];
+
+      const instructionsHash = computeInstructionsHash(compactIxs);
+      const tx2AccountMetas = [
+        { pubkey: ctx.payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: walletPda, isSigner: false, isWritable: false },
+        { pubkey: vaultPda, isSigner: false, isWritable: true },
+        { pubkey: PublicKey.default, isSigner: false, isWritable: true },
+        { pubkey: ctx.payer.publicKey, isSigner: false, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+        { pubkey: recipient1, isSigner: false, isWritable: true },
+        { pubkey: recipient2, isSigner: false, isWritable: true },
+        { pubkey: recipient3, isSigner: false, isWritable: true },
+      ];
+      const accountsHash = computeAccountsHash(tx2AccountMetas, compactIxs);
+      const signedPayload = Buffer.concat([instructionsHash, accountsHash]);
+
+      // Counter is now 2 (after first test incremented to 1)
+      const { authPayload, precompileIx } = await signSecp256r1({
+        key: ownerKey,
+        discriminator: new Uint8Array([DISC_AUTHORIZE]),
+        signedPayload,
+        slot,
+        counter: 2,
+        payer: ctx.payer.publicKey,
+        sysvarIxIndex: 6,
+      });
+
+      const [deferredExecPda] = findDeferredExecPda(walletPda, ownerAuthorityPda, 2);
+
+      // TX1: Authorize
+      await sendTx(ctx, [precompileIx, createAuthorizeIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        authorityPda: ownerAuthorityPda,
+        deferredExecPda,
+        instructionsHash,
+        accountsHash,
+        expiryOffset: 300,
+        authPayload,
+      })]);
+
+      // TX2: ExecuteDeferred
+      const packed = packCompactInstructions(compactIxs);
+      await sendTx(ctx, [createExecuteDeferredIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        vaultPda,
+        deferredExecPda,
+        refundDestination: ctx.payer.publicKey,
+        packedInstructions: packed,
+        remainingAccounts: [
+          { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+          { pubkey: recipient1, isSigner: false, isWritable: true },
+          { pubkey: recipient2, isSigner: false, isWritable: true },
+          { pubkey: recipient3, isSigner: false, isWritable: true },
+        ],
+      })]);
+
+      // Verify all transfers
+      const bal1 = await ctx.connection.getBalance(recipient1);
+      const bal2 = await ctx.connection.getBalance(recipient2);
+      const bal3 = await ctx.connection.getBalance(recipient3);
+      expect(bal1).toBe(LAMPORTS_PER_SOL);
+      expect(bal2).toBe(LAMPORTS_PER_SOL);
+      expect(bal3).toBe(LAMPORTS_PER_SOL);
+    });
+  });
+
+  describe('Security', () => {
+    let walletPda: PublicKey;
+    let vaultPda: PublicKey;
+    let ownerKey: Awaited<ReturnType<typeof generateMockSecp256r1Key>>;
+    let ownerAuthorityPda: PublicKey;
+
+    beforeAll(async () => {
+      ownerKey = await generateMockSecp256r1Key();
+      const userSeed = crypto.randomBytes(32);
+
+      [walletPda] = findWalletPda(userSeed);
+      [vaultPda] = findVaultPda(walletPda);
+      const [authPda, authBump] = findAuthorityPda(walletPda, ownerKey.credentialIdHash);
+      ownerAuthorityPda = authPda;
+
+      await sendTx(ctx, [createCreateWalletIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        vaultPda,
+        authorityPda: authPda,
+        userSeed,
+        authType: AUTH_TYPE_SECP256R1,
+        authBump,
+        credentialOrPubkey: ownerKey.credentialIdHash,
+        secp256r1Pubkey: ownerKey.publicKeyBytes,
+        rpId: ownerKey.rpId,
+      })]);
+
+      const sig = await ctx.connection.requestAirdrop(vaultPda, 5 * LAMPORTS_PER_SOL);
+      await ctx.connection.confirmTransaction(sig, 'confirmed');
+    });
+
+    it('rejects ExecuteDeferred with wrong instructions (hash mismatch)', async () => {
+      const recipient = Keypair.generate().publicKey;
+      const slot = await getSlot(ctx);
+
+      const transferData = Buffer.alloc(12);
+      transferData.writeUInt32LE(2, 0);
+      transferData.writeBigUInt64LE(BigInt(LAMPORTS_PER_SOL), 4);
+
+      // Authorize with 100k transfer
+      const compactIxs = [{
+        programIdIndex: 5,
+        accountIndexes: [2, 6],
+        data: new Uint8Array(transferData),
+      }];
+
+      const instructionsHash = computeInstructionsHash(compactIxs);
+      const tx2AccountMetas = [
+        { pubkey: ctx.payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: walletPda, isSigner: false, isWritable: false },
+        { pubkey: vaultPda, isSigner: false, isWritable: true },
+        { pubkey: PublicKey.default, isSigner: false, isWritable: true },
+        { pubkey: ctx.payer.publicKey, isSigner: false, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+        { pubkey: recipient, isSigner: false, isWritable: true },
+      ];
+      const accountsHash = computeAccountsHash(tx2AccountMetas, compactIxs);
+      const signedPayload = Buffer.concat([instructionsHash, accountsHash]);
+
+      const { authPayload, precompileIx } = await signSecp256r1({
+        key: ownerKey,
+        discriminator: new Uint8Array([DISC_AUTHORIZE]),
+        signedPayload,
+        slot,
+        counter: 1,
+        payer: ctx.payer.publicKey,
+        sysvarIxIndex: 6,
+      });
+
+      const [deferredExecPda] = findDeferredExecPda(walletPda, ownerAuthorityPda, 1);
+
+      // TX1: Authorize
+      await sendTx(ctx, [precompileIx, createAuthorizeIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        authorityPda: ownerAuthorityPda,
+        deferredExecPda,
+        instructionsHash,
+        accountsHash,
+        expiryOffset: 300,
+        authPayload,
+      })]);
+
+      // TX2: Try to execute with DIFFERENT instructions (1M instead of 100k)
+      const wrongTransferData = Buffer.alloc(12);
+      wrongTransferData.writeUInt32LE(2, 0);
+      wrongTransferData.writeBigUInt64LE(BigInt(2 * LAMPORTS_PER_SOL), 4); // 2 SOL instead of 1 SOL
+
+      const wrongCompactIxs = [{
+        programIdIndex: 5,
+        accountIndexes: [2, 6],
+        data: new Uint8Array(wrongTransferData),
+      }];
+      const wrongPacked = packCompactInstructions(wrongCompactIxs);
+
+      await sendTxExpectError(ctx, [createExecuteDeferredIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        vaultPda,
+        deferredExecPda,
+        refundDestination: ctx.payer.publicKey,
+        packedInstructions: wrongPacked,
+        remainingAccounts: [
+          { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+          { pubkey: recipient, isSigner: false, isWritable: true },
+        ],
+      })], [], 3015); // DeferredHashMismatch
+
+      // Now execute with correct instructions to clean up
+      const correctPacked = packCompactInstructions(compactIxs);
+      await sendTx(ctx, [createExecuteDeferredIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        vaultPda,
+        deferredExecPda,
+        refundDestination: ctx.payer.publicKey,
+        packedInstructions: correctPacked,
+        remainingAccounts: [
+          { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+          { pubkey: recipient, isSigner: false, isWritable: true },
+        ],
+      })]);
+    });
+
+    it('rejects double execution (account closed after first execute)', async () => {
+      const recipient = Keypair.generate().publicKey;
+      const slot = await getSlot(ctx);
+
+      const transferData = Buffer.alloc(12);
+      transferData.writeUInt32LE(2, 0);
+      transferData.writeBigUInt64LE(BigInt(LAMPORTS_PER_SOL), 4);
+
+      const compactIxs = [{
+        programIdIndex: 5,
+        accountIndexes: [2, 6],
+        data: new Uint8Array(transferData),
+      }];
+
+      const instructionsHash = computeInstructionsHash(compactIxs);
+      const tx2AccountMetas = [
+        { pubkey: ctx.payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: walletPda, isSigner: false, isWritable: false },
+        { pubkey: vaultPda, isSigner: false, isWritable: true },
+        { pubkey: PublicKey.default, isSigner: false, isWritable: true },
+        { pubkey: ctx.payer.publicKey, isSigner: false, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+        { pubkey: recipient, isSigner: false, isWritable: true },
+      ];
+      const accountsHash = computeAccountsHash(tx2AccountMetas, compactIxs);
+      const signedPayload = Buffer.concat([instructionsHash, accountsHash]);
+
+      const { authPayload, precompileIx } = await signSecp256r1({
+        key: ownerKey,
+        discriminator: new Uint8Array([DISC_AUTHORIZE]),
+        signedPayload,
+        slot,
+        counter: 2,
+        payer: ctx.payer.publicKey,
+        sysvarIxIndex: 6,
+      });
+
+      const [deferredExecPda] = findDeferredExecPda(walletPda, ownerAuthorityPda, 2);
+
+      // TX1: Authorize
+      await sendTx(ctx, [precompileIx, createAuthorizeIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        authorityPda: ownerAuthorityPda,
+        deferredExecPda,
+        instructionsHash,
+        accountsHash,
+        expiryOffset: 300,
+        authPayload,
+      })]);
+
+      // TX2: Execute (should succeed)
+      const packed = packCompactInstructions(compactIxs);
+      const executeDeferredIx = createExecuteDeferredIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        vaultPda,
+        deferredExecPda,
+        refundDestination: ctx.payer.publicKey,
+        packedInstructions: packed,
+        remainingAccounts: [
+          { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+          { pubkey: recipient, isSigner: false, isWritable: true },
+        ],
+      });
+
+      await sendTx(ctx, [executeDeferredIx]);
+
+      // TX2 again: should fail (account closed)
+      await sendTxExpectError(ctx, [createExecuteDeferredIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        vaultPda,
+        deferredExecPda,
+        refundDestination: ctx.payer.publicKey,
+        packedInstructions: packed,
+        remainingAccounts: [
+          { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+          { pubkey: recipient, isSigner: false, isWritable: true },
+        ],
+      })]);
+    });
+
+    it('rejects reclaim before expiry', async () => {
+      const recipient = Keypair.generate().publicKey;
+      const slot = await getSlot(ctx);
+
+      const transferData = Buffer.alloc(12);
+      transferData.writeUInt32LE(2, 0);
+      transferData.writeBigUInt64LE(BigInt(LAMPORTS_PER_SOL), 4);
+
+      const compactIxs = [{
+        programIdIndex: 5,
+        accountIndexes: [2, 6],
+        data: new Uint8Array(transferData),
+      }];
+
+      const instructionsHash = computeInstructionsHash(compactIxs);
+      const tx2AccountMetas = [
+        { pubkey: ctx.payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: walletPda, isSigner: false, isWritable: false },
+        { pubkey: vaultPda, isSigner: false, isWritable: true },
+        { pubkey: PublicKey.default, isSigner: false, isWritable: true },
+        { pubkey: ctx.payer.publicKey, isSigner: false, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+        { pubkey: recipient, isSigner: false, isWritable: true },
+      ];
+      const accountsHash = computeAccountsHash(tx2AccountMetas, compactIxs);
+      const signedPayload = Buffer.concat([instructionsHash, accountsHash]);
+
+      const { authPayload, precompileIx } = await signSecp256r1({
+        key: ownerKey,
+        discriminator: new Uint8Array([DISC_AUTHORIZE]),
+        signedPayload,
+        slot,
+        counter: 3,
+        payer: ctx.payer.publicKey,
+        sysvarIxIndex: 6,
+      });
+
+      const [deferredExecPda] = findDeferredExecPda(walletPda, ownerAuthorityPda, 3);
+
+      // TX1: Authorize with max expiry
+      await sendTx(ctx, [precompileIx, createAuthorizeIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        authorityPda: ownerAuthorityPda,
+        deferredExecPda,
+        instructionsHash,
+        accountsHash,
+        expiryOffset: 9000, // ~1 hour
+        authPayload,
+      })]);
+
+      // Try to reclaim immediately (should fail — not expired yet)
+      await sendTxExpectError(ctx, [createReclaimDeferredIx({
+        payer: ctx.payer.publicKey,
+        deferredExecPda,
+        refundDestination: ctx.payer.publicKey,
+      })], [], 3018); // DeferredAuthorizationNotExpired
+
+      // Clean up: execute it
+      const packed = packCompactInstructions(compactIxs);
+      await sendTx(ctx, [createExecuteDeferredIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        vaultPda,
+        deferredExecPda,
+        refundDestination: ctx.payer.publicKey,
+        packedInstructions: packed,
+        remainingAccounts: [
+          { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+          { pubkey: recipient, isSigner: false, isWritable: true },
+        ],
+      })]);
+    });
+
+    it('rejects reclaim from wrong payer', async () => {
+      const recipient = Keypair.generate().publicKey;
+      const slot = await getSlot(ctx);
+
+      const transferData = Buffer.alloc(12);
+      transferData.writeUInt32LE(2, 0);
+      transferData.writeBigUInt64LE(BigInt(LAMPORTS_PER_SOL), 4);
+
+      const compactIxs = [{
+        programIdIndex: 5,
+        accountIndexes: [2, 6],
+        data: new Uint8Array(transferData),
+      }];
+
+      const instructionsHash = computeInstructionsHash(compactIxs);
+      const tx2AccountMetas = [
+        { pubkey: ctx.payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: walletPda, isSigner: false, isWritable: false },
+        { pubkey: vaultPda, isSigner: false, isWritable: true },
+        { pubkey: PublicKey.default, isSigner: false, isWritable: true },
+        { pubkey: ctx.payer.publicKey, isSigner: false, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+        { pubkey: recipient, isSigner: false, isWritable: true },
+      ];
+      const accountsHash = computeAccountsHash(tx2AccountMetas, compactIxs);
+      const signedPayload = Buffer.concat([instructionsHash, accountsHash]);
+
+      const { authPayload, precompileIx } = await signSecp256r1({
+        key: ownerKey,
+        discriminator: new Uint8Array([DISC_AUTHORIZE]),
+        signedPayload,
+        slot,
+        counter: 4,
+        payer: ctx.payer.publicKey,
+        sysvarIxIndex: 6,
+      });
+
+      const [deferredExecPda] = findDeferredExecPda(walletPda, ownerAuthorityPda, 4);
+
+      // TX1: Authorize with short expiry
+      await sendTx(ctx, [precompileIx, createAuthorizeIx({
+        payer: ctx.payer.publicKey,
+        walletPda,
+        authorityPda: ownerAuthorityPda,
+        deferredExecPda,
+        instructionsHash,
+        accountsHash,
+        expiryOffset: 10, // minimum expiry
+        authPayload,
+      })]);
+
+      // Create a different payer and try to reclaim
+      const wrongPayer = Keypair.generate();
+      const airdropSig = await ctx.connection.requestAirdrop(wrongPayer.publicKey, LAMPORTS_PER_SOL);
+      await ctx.connection.confirmTransaction(airdropSig, 'confirmed');
+
+      // Even if expired, wrong payer should fail
+      // Wait for expiry by sending some transactions to advance slots
+      for (let i = 0; i < 5; i++) {
+        await ctx.connection.requestAirdrop(Keypair.generate().publicKey, 1000);
+      }
+
+      await sendTxExpectError(ctx, [createReclaimDeferredIx({
+        payer: wrongPayer.publicKey,
+        deferredExecPda,
+        refundDestination: wrongPayer.publicKey,
+      })], [wrongPayer], 3017); // UnauthorizedReclaim
+
+      // Clean up: execute with correct payer
+      const packed = packCompactInstructions(compactIxs);
+      // Wait for more slots just in case expiry hasn't passed
+      // If expired, this will fail too — but it's fine since we proved the wrong payer was rejected
+      try {
+        await sendTx(ctx, [createExecuteDeferredIx({
+          payer: ctx.payer.publicKey,
+          walletPda,
+          vaultPda,
+          deferredExecPda,
+          refundDestination: ctx.payer.publicKey,
+          packedInstructions: packed,
+          remainingAccounts: [
+            { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+            { pubkey: recipient, isSigner: false, isWritable: true },
+          ],
+        })]);
+      } catch {
+        // May have expired — that's fine, reclaim with correct payer
+        await sendTx(ctx, [createReclaimDeferredIx({
+          payer: ctx.payer.publicKey,
+          deferredExecPda,
+          refundDestination: ctx.payer.publicKey,
+        })]);
+      }
+    });
+
+    it('counter increments correctly across deferred and regular execute', async () => {
+      // After 4 deferred authorizations, counter should be 4
+      const authority = await ctx.connection.getAccountInfo(ownerAuthorityPda);
+      const view = new DataView(authority!.data.buffer, authority!.data.byteOffset);
+      const counter = view.getUint32(8, true);
+      expect(counter).toBe(4);
+    });
+  });
+});

--- a/tests-sdk/tests/benchmark.ts
+++ b/tests-sdk/tests/benchmark.ts
@@ -34,10 +34,15 @@ import {
   computeAccountsHash,
   AUTH_TYPE_ED25519,
   AUTH_TYPE_SECP256R1,
+  findDeferredExecPda,
   DISC_ADD_AUTHORITY,
   DISC_EXECUTE,
+  DISC_AUTHORIZE,
   ROLE_ADMIN,
   PROGRAM_ID,
+  createAuthorizeIx,
+  createExecuteDeferredIx,
+  computeInstructionsHash,
 } from '../../sdk/solita-client/src';
 import { generateMockSecp256r1Key, signSecp256r1 } from './secp256r1Utils';
 
@@ -458,6 +463,260 @@ async function benchExecuteSession(connection: Connection, payer: Keypair): Prom
   };
 }
 
+// ─── Deferred Execution Benchmarks ───────────────────────────────────────────
+
+async function benchDeferredExecution(
+  connection: Connection,
+  payer: Keypair,
+): Promise<{ authorize: BenchResult; executeDeferred: BenchResult }> {
+  // Setup: create Secp256r1 wallet
+  const key = await generateMockSecp256r1Key();
+  const userSeed = crypto.randomBytes(32);
+
+  const [walletPda] = findWalletPda(userSeed);
+  const [vaultPda] = findVaultPda(walletPda);
+  const [authPda, authBump] = findAuthorityPda(walletPda, key.credentialIdHash);
+
+  await sendAndMeasure(connection, payer, [createCreateWalletIx({
+    payer: payer.publicKey,
+    walletPda,
+    vaultPda,
+    authorityPda: authPda,
+    userSeed,
+    authType: AUTH_TYPE_SECP256R1,
+    authBump,
+    credentialOrPubkey: key.credentialIdHash,
+    secp256r1Pubkey: key.publicKeyBytes,
+    rpId: key.rpId,
+  })]);
+
+  // Fund vault
+  const airdropSig = await connection.requestAirdrop(vaultPda, 10 * LAMPORTS_PER_SOL);
+  await connection.confirmTransaction(airdropSig, 'confirmed');
+
+  const recipient = Keypair.generate().publicKey;
+  const slot = await getSlot(connection);
+
+  // Build SOL transfer as compact instruction
+  const transferData = Buffer.alloc(12);
+  transferData.writeUInt32LE(2, 0);
+  transferData.writeBigUInt64LE(BigInt(LAMPORTS_PER_SOL), 4);
+
+  // TX2 account layout:
+  //   0: payer, 1: wallet, 2: vault, 3: deferred, 4: refundDest
+  //   5: SystemProgram, 6: recipient
+  const compactIxs = [{
+    programIdIndex: 5,
+    accountIndexes: [2, 6],
+    data: new Uint8Array(transferData),
+  }];
+
+  // Compute hashes
+  const instructionsHash = computeInstructionsHash(compactIxs);
+  const tx2AccountMetas = [
+    { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+    { pubkey: walletPda, isSigner: false, isWritable: false },
+    { pubkey: vaultPda, isSigner: false, isWritable: true },
+    { pubkey: PublicKey.default, isSigner: false, isWritable: true }, // deferred placeholder
+    { pubkey: payer.publicKey, isSigner: false, isWritable: true },
+    { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    { pubkey: recipient, isSigner: false, isWritable: true },
+  ];
+  const accountsHash = computeAccountsHash(tx2AccountMetas, compactIxs);
+
+  const signedPayload = Buffer.concat([instructionsHash, accountsHash]);
+
+  const { authPayload, precompileIx } = await signSecp256r1({
+    key,
+    discriminator: new Uint8Array([DISC_AUTHORIZE]),
+    signedPayload,
+    slot,
+    counter: 1,
+    payer: payer.publicKey,
+    sysvarIxIndex: 6,
+  });
+
+  const [deferredExecPda] = findDeferredExecPda(walletPda, authPda, 1);
+
+  // === TX1: Authorize ===
+  const authorizeIx = createAuthorizeIx({
+    payer: payer.publicKey,
+    walletPda,
+    authorityPda: authPda,
+    deferredExecPda,
+    instructionsHash,
+    accountsHash,
+    expiryOffset: 300,
+    authPayload,
+  });
+
+  const authResult = await sendAndMeasure(connection, payer, [precompileIx, authorizeIx]);
+  const authorizeResult: BenchResult = {
+    name: 'Deferred: Authorize (TX1)',
+    cu: authResult.cu,
+    txSize: authResult.txSize,
+    ixData: authResult.ixDataSizes.reduce((a, b) => a + b, 0),
+    accounts: authResult.accountCounts[authResult.accountCounts.length - 1],
+    instructions: 2,
+  };
+
+  // === TX2: ExecuteDeferred ===
+  const packed = packCompactInstructions(compactIxs);
+  const executeDeferredIx = createExecuteDeferredIx({
+    payer: payer.publicKey,
+    walletPda,
+    vaultPda,
+    deferredExecPda,
+    refundDestination: payer.publicKey,
+    packedInstructions: packed,
+    remainingAccounts: [
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      { pubkey: recipient, isSigner: false, isWritable: true },
+    ],
+  });
+
+  const execResult = await sendAndMeasure(connection, payer, [executeDeferredIx]);
+  const executeDeferredResult: BenchResult = {
+    name: 'Deferred: ExecuteDeferred (TX2)',
+    cu: execResult.cu,
+    txSize: execResult.txSize,
+    ixData: execResult.ixDataSizes[0],
+    accounts: execResult.accountCounts[0],
+    instructions: 1,
+  };
+
+  return { authorize: authorizeResult, executeDeferred: executeDeferredResult };
+}
+
+async function benchDeferredMultiInstruction(
+  connection: Connection,
+  payer: Keypair,
+): Promise<{ authorize: BenchResult; executeDeferred: BenchResult }> {
+  // Setup: create Secp256r1 wallet
+  const key = await generateMockSecp256r1Key();
+  const userSeed = crypto.randomBytes(32);
+
+  const [walletPda] = findWalletPda(userSeed);
+  const [vaultPda] = findVaultPda(walletPda);
+  const [authPda, authBump] = findAuthorityPda(walletPda, key.credentialIdHash);
+
+  await sendAndMeasure(connection, payer, [createCreateWalletIx({
+    payer: payer.publicKey,
+    walletPda,
+    vaultPda,
+    authorityPda: authPda,
+    userSeed,
+    authType: AUTH_TYPE_SECP256R1,
+    authBump,
+    credentialOrPubkey: key.credentialIdHash,
+    secp256r1Pubkey: key.publicKeyBytes,
+    rpId: key.rpId,
+  })]);
+
+  // Fund vault
+  const airdropSig = await connection.requestAirdrop(vaultPda, 10 * LAMPORTS_PER_SOL);
+  await connection.confirmTransaction(airdropSig, 'confirmed');
+
+  const recipient1 = Keypair.generate().publicKey;
+  const recipient2 = Keypair.generate().publicKey;
+  const recipient3 = Keypair.generate().publicKey;
+  const slot = await getSlot(connection);
+
+  const makeTransferData = (amount: bigint) => {
+    const buf = Buffer.alloc(12);
+    buf.writeUInt32LE(2, 0);
+    buf.writeBigUInt64LE(amount, 4);
+    return new Uint8Array(buf);
+  };
+
+  // TX2 layout:
+  //   0: payer, 1: wallet, 2: vault, 3: deferred, 4: refundDest
+  //   5: SystemProgram, 6: recipient1, 7: recipient2, 8: recipient3
+  const compactIxs = [
+    { programIdIndex: 5, accountIndexes: [2, 6], data: makeTransferData(BigInt(LAMPORTS_PER_SOL)) },
+    { programIdIndex: 5, accountIndexes: [2, 7], data: makeTransferData(BigInt(LAMPORTS_PER_SOL)) },
+    { programIdIndex: 5, accountIndexes: [2, 8], data: makeTransferData(BigInt(LAMPORTS_PER_SOL)) },
+  ];
+
+  const instructionsHash = computeInstructionsHash(compactIxs);
+  const tx2AccountMetas = [
+    { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+    { pubkey: walletPda, isSigner: false, isWritable: false },
+    { pubkey: vaultPda, isSigner: false, isWritable: true },
+    { pubkey: PublicKey.default, isSigner: false, isWritable: true },
+    { pubkey: payer.publicKey, isSigner: false, isWritable: true },
+    { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    { pubkey: recipient1, isSigner: false, isWritable: true },
+    { pubkey: recipient2, isSigner: false, isWritable: true },
+    { pubkey: recipient3, isSigner: false, isWritable: true },
+  ];
+  const accountsHash = computeAccountsHash(tx2AccountMetas, compactIxs);
+  const signedPayload = Buffer.concat([instructionsHash, accountsHash]);
+
+  const { authPayload, precompileIx } = await signSecp256r1({
+    key,
+    discriminator: new Uint8Array([DISC_AUTHORIZE]),
+    signedPayload,
+    slot,
+    counter: 1,
+    payer: payer.publicKey,
+    sysvarIxIndex: 6,
+  });
+
+  const [deferredExecPda] = findDeferredExecPda(walletPda, authPda, 1);
+
+  // TX1: Authorize
+  const authorizeIx = createAuthorizeIx({
+    payer: payer.publicKey,
+    walletPda,
+    authorityPda: authPda,
+    deferredExecPda,
+    instructionsHash,
+    accountsHash,
+    expiryOffset: 300,
+    authPayload,
+  });
+
+  const authResult = await sendAndMeasure(connection, payer, [precompileIx, authorizeIx]);
+  const authorizeResult: BenchResult = {
+    name: 'Deferred Multi-IX: Authorize (TX1)',
+    cu: authResult.cu,
+    txSize: authResult.txSize,
+    ixData: authResult.ixDataSizes.reduce((a, b) => a + b, 0),
+    accounts: authResult.accountCounts[authResult.accountCounts.length - 1],
+    instructions: 2,
+  };
+
+  // TX2: ExecuteDeferred (3 transfers)
+  const packed = packCompactInstructions(compactIxs);
+  const executeDeferredIx = createExecuteDeferredIx({
+    payer: payer.publicKey,
+    walletPda,
+    vaultPda,
+    deferredExecPda,
+    refundDestination: payer.publicKey,
+    packedInstructions: packed,
+    remainingAccounts: [
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+      { pubkey: recipient1, isSigner: false, isWritable: true },
+      { pubkey: recipient2, isSigner: false, isWritable: true },
+      { pubkey: recipient3, isSigner: false, isWritable: true },
+    ],
+  });
+
+  const execResult = await sendAndMeasure(connection, payer, [executeDeferredIx]);
+  const executeDeferredResult: BenchResult = {
+    name: 'Deferred Multi-IX: ExecuteDeferred (TX2)',
+    cu: execResult.cu,
+    txSize: execResult.txSize,
+    ixData: execResult.ixDataSizes[0],
+    accounts: execResult.accountCounts[0],
+    instructions: 1,
+  };
+
+  return { authorize: authorizeResult, executeDeferred: executeDeferredResult };
+}
+
 // ─── Rent Calculations ────────────────────────────────────────────────────────
 
 function calculateRent(dataSize: number): number {
@@ -505,6 +764,30 @@ async function main() {
     }
   }
 
+  // Run deferred execution benchmarks (these return 2 results each)
+  let deferredSingle: { authorize: BenchResult; executeDeferred: BenchResult } | null = null;
+  let deferredMulti: { authorize: BenchResult; executeDeferred: BenchResult } | null = null;
+
+  try {
+    process.stdout.write('  Deferred Single (Authorize + Execute)... ');
+    deferredSingle = await benchDeferredExecution(connection, payer);
+    results.push(deferredSingle.authorize);
+    results.push(deferredSingle.executeDeferred);
+    console.log(`TX1: ${deferredSingle.authorize.cu} CU, TX2: ${deferredSingle.executeDeferred.cu} CU`);
+  } catch (err: any) {
+    console.log(`FAILED: ${err.message?.slice(0, 80)}`);
+  }
+
+  try {
+    process.stdout.write('  Deferred Multi-IX (3 transfers)... ');
+    deferredMulti = await benchDeferredMultiInstruction(connection, payer);
+    results.push(deferredMulti.authorize);
+    results.push(deferredMulti.executeDeferred);
+    console.log(`TX1: ${deferredMulti.authorize.cu} CU, TX2: ${deferredMulti.executeDeferred.cu} CU`);
+  } catch (err: any) {
+    console.log(`FAILED: ${err.message?.slice(0, 80)}`);
+  }
+
   // ─── Output Tables ────────────────────────────────────────────────────────
 
   console.log('\n\n## Compute Units & Transaction Size\n');
@@ -532,6 +815,32 @@ async function main() {
     console.log(`| Transaction Fee | 0.000005 SOL | 0.000005 SOL | 0.000005 SOL | Same base fee |`);
   }
 
+  // ─── Deferred vs Immediate Execute Comparison ─────────────────────────────
+
+  if (secp256r1Result && deferredSingle) {
+    const totalDeferredCU = deferredSingle.authorize.cu + deferredSingle.executeDeferred.cu;
+    const deferredRent = calculateRent(176);
+
+    console.log('\n\n## Deferred Execution vs Immediate Execute (Secp256r1)\n');
+    console.log('| Metric | Immediate Execute | Deferred TX1 (Authorize) | Deferred TX2 (Execute) | Deferred Total | Notes |');
+    console.log('|---|---|---|---|---|---|');
+    console.log(`| Compute Units | ${secp256r1Result.cu.toLocaleString()} | ${deferredSingle.authorize.cu.toLocaleString()} | ${deferredSingle.executeDeferred.cu.toLocaleString()} | ${totalDeferredCU.toLocaleString()} | Deferred splits CU across 2 txs |`);
+    console.log(`| Tx Size (bytes) | ${secp256r1Result.txSize} | ${deferredSingle.authorize.txSize} | ${deferredSingle.executeDeferred.txSize} | ${deferredSingle.authorize.txSize + deferredSingle.executeDeferred.txSize} | TX2 has no precompile overhead |`);
+    console.log(`| Inner Ix Capacity | ~574 bytes | N/A (hashes only) | ~1,100 bytes | ~1,100 bytes | 1.9x more space for inner instructions |`);
+    console.log(`| Tx Fees | 0.000005 SOL | 0.000005 SOL | 0.000005 SOL | 0.00001 SOL | 2x fee for 2 transactions |`);
+    console.log(`| Temp Rent (refunded) | — | ${(deferredRent / LAMPORTS_PER_SOL).toFixed(9)} SOL | refunded | 0 SOL net | DeferredExec rent refunded on close |`);
+    console.log(`| Accounts | ${secp256r1Result.accounts} | ${deferredSingle.authorize.accounts} | ${deferredSingle.executeDeferred.accounts} | — | TX2 doesn't need precompile sysvar |`);
+  }
+
+  if (deferredMulti) {
+    console.log('\n\n## Deferred Multi-Instruction (3 SOL Transfers)\n');
+    console.log('| Phase | CU | Tx Size (bytes) | Accounts | Notes |');
+    console.log('|---|---|---|---|---|');
+    console.log(`| TX1: Authorize | ${deferredMulti.authorize.cu.toLocaleString()} | ${deferredMulti.authorize.txSize} | ${deferredMulti.authorize.accounts} | Same cost regardless of inner ix count |`);
+    console.log(`| TX2: Execute 3 transfers | ${deferredMulti.executeDeferred.cu.toLocaleString()} | ${deferredMulti.executeDeferred.txSize} | ${deferredMulti.executeDeferred.accounts} | 3 CPIs + hash verification |`);
+    console.log(`| Total | ${(deferredMulti.authorize.cu + deferredMulti.executeDeferred.cu).toLocaleString()} | ${deferredMulti.authorize.txSize + deferredMulti.executeDeferred.txSize} | — | |`);
+  }
+
   // ─── Rent Costs ───────────────────────────────────────────────────────────
 
   const rentData = [
@@ -539,6 +848,7 @@ async function main() {
     { name: 'Authority (Ed25519)', dataSize: 80 },
     { name: 'Authority (Secp256r1)', dataSize: 125 }, // 48 header + 32 cred_hash + 33 pubkey + 1 rpIdLen + ~11 rpId
     { name: 'Session', dataSize: 80 },
+    { name: 'DeferredExec (temporary)', dataSize: 176 },
   ];
 
   console.log('\n\n## Rent-Exempt Costs\n');

--- a/tests-sdk/tests/common.ts
+++ b/tests-sdk/tests/common.ts
@@ -9,7 +9,7 @@ import {
   type Signer,
 } from '@solana/web3.js';
 
-export const PROGRAM_ID = new PublicKey('2m47smrvCRpuqAyX2dLqPxpAC1658n1BAQga1wRCsQiT');
+export const PROGRAM_ID = new PublicKey('FLb7fyAtkfA4TSa2uYcAT8QKHd2pkoMHgmqfnXFXo7ao');
 export const RPC_URL = process.env.RPC_URL || 'http://127.0.0.1:8899';
 
 export interface TestContext {


### PR DESCRIPTION
## Summary

- **Deferred Execution**: 2-transaction flow for large payloads exceeding the ~574-byte limit of a single Secp256r1 Execute tx (e.g., Jupiter swaps). TX1 (Authorize) signs over instruction/account hashes and creates a DeferredExec PDA. TX2 (ExecuteDeferred) verifies hashes and executes via CPI with vault signing. ReclaimDeferred closes expired authorizations and refunds rent.
- **Odometer replay protection**: Replaced unreliable WebAuthn hardware counter with program-controlled monotonic u32 counter per authority. Works reliably with synced passkeys (iCloud, Google).
- **Tx size optimization (708 to 658 bytes)**: Replaced SlotHashes sysvar with `Clock::get()` (removes 1 account), counter u64 to u32 (saves 8 bytes), rpId stored on authority account at creation (saves ~14 bytes per tx).
- **Solita SDK**: Replaced Codama-generated SDK with Solita-generated TypeScript SDK (`sdk/solita-client`) including instruction builders, PDA helpers, Secp256r1 signing utils, and `LazorKitClient` high-level API.
- **35 integration tests**: Full test suite (`tests-sdk/`) covering wallet lifecycle, authority management, execute, deferred execution, sessions, replay protection, counter edge cases, and end-to-end workflows.
- **Audit fixes**: 17/17 security issues resolved (Accretion audit) -- version gate, length validation, self-removal protection, session expiry checks.
- **Documentation**: Comprehensive open-source docs -- README with benchmark tables, Architecture, Costs (real CU measurements), SDK API reference, CHANGELOG, SECURITY.md, CONTRIBUTING.md.

## Benchmark Results

| Instruction | CU | Tx Size | Accounts |
|---|---|---|---|
| Normal SOL Transfer (baseline) | 150 | 215 bytes | 2 |
| CreateWallet (Ed25519) | 15,187 | 408 bytes | 6 |
| CreateWallet (Secp256r1) | 13,687 | 453 bytes | 6 |
| AddAuthority (Ed25519 admin) | 5,846 | 473 bytes | 7 |
| Execute Secp256r1 (SOL transfer) | 12,441 | 658 bytes | 7 |
| Execute Session (SOL transfer) | 8,983 | 452 bytes | 7 |
| Authorize (Deferred TX1) | 11,709 | 705 bytes | 7 |
| ExecuteDeferred (TX2) | 6,904 | 356 bytes | 7 |

## New Instructions

| Disc | Instruction | Description |
|---|---|---|
| 6 | Authorize | TX1: sign over instruction/account hashes, create DeferredExec PDA |
| 7 | ExecuteDeferred | TX2: verify hashes, close DeferredExec, execute via CPI |
| 8 | ReclaimDeferred | Close expired DeferredExec, refund rent to original payer |

## New Error Codes

| Code | Name |
|---|---|
| 3014 | DeferredAuthorizationExpired |
| 3015 | DeferredHashMismatch |
| 3016 | InvalidExpiryWindow |
| 3017 | UnauthorizedReclaim |
| 3018 | DeferredAuthorizationNotExpired |

## Test plan

- [x] `cargo test` -- 34 Rust tests pass
- [x] `cd tests-sdk && npx vitest run` -- 35 integration tests pass (8 test files)
- [x] `npm run benchmark` -- CU and tx size numbers match documentation
- [x] `cargo build-sbf` -- program builds cleanly
- [x] Verify deferred execution flow: Authorize -> ExecuteDeferred succeeds
- [x] Verify deferred expiry: ReclaimDeferred works after expiry
- [x] Verify all doc links resolve (README -> Architecture, Costs, SDK API)