### PR TITLE
chore(tests-sdk): use shared validator ledger at $HOME/test-ledger

### DIFF
--- a/tests-sdk/package.json
+++ b/tests-sdk/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "vitest run --fileParallelism=false",
     "test:watch": "vitest --fileParallelism=false",
-    "validator:start": "cd ../program && cargo build-sbf --features devnet && cd - && solana-test-validator --bpf-program $(solana-keygen pubkey ../target/deploy/lazorkit_program-keypair.json) ../target/deploy/lazorkit_program.so --reset",
+    "validator:start": "cd ../program && cargo build-sbf --features devnet && cd - && solana-test-validator --ledger \"$HOME/test-ledger\" --bpf-program $(solana-keygen pubkey ../target/deploy/lazorkit_program-keypair.json) ../target/deploy/lazorkit_program.so --reset",
+    "validator:stop": "pkill -f solana-test-validator || true",
     "benchmark": "npx tsx tests/benchmark.ts",
     "pretest": "echo 'Ensure solana-test-validator is running with the program loaded'"
   },


### PR DESCRIPTION
## Summary

\`solana-test-validator\` defaults to creating \`test-ledger/\` in cwd, so each repo keeps its own ~150 MB ledger. Switch the \`validator:start\` script to \`--ledger "\$HOME/test-ledger"\` so this repo and the sibling \`lazorkit-protocol\` repo share one location.

Also exposes a \`validator:stop\` helper for symmetry — already present in \`lazorkit-protocol\`'s tests-sdk.

The \`--reset\` flag wipes the ledger on every run, so sequential test runs across repos still start from a fresh state — there's no cross-contamination risk from sharing.

## Test plan

- [ ] \`npm run validator:start\` creates / wipes \`\$HOME/test-ledger\`, not \`tests-sdk/test-ledger\`
- [ ] \`npm test\` passes (65/65 tests on a freshly built devnet binary)