### PR TITLE
chore(repo): add CODEOWNERS, PR template, dependabot config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Code owners for lazor-kit/program-v2
+#
+# Order matters — the LAST matching pattern wins. Use specific
+# overrides below the catch-all when you want to scope ownership.
+#
+# Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default: any change requires review from one of the maintainers
+*                       @onspeedhp @chauanhtuan185 @metasal1
+
+# Audit-sensitive paths — additional eyes on changes that affect on-chain
+# behavior or release artifacts
+/program/               @onspeedhp @chauanhtuan185 @metasal1
+/assertions/            @onspeedhp @chauanhtuan185 @metasal1
+/.github/workflows/     @onspeedhp @chauanhtuan185 @metasal1
+/audits/                @onspeedhp @chauanhtuan185 @metasal1
+/scripts/fee-paths.txt  @onspeedhp @chauanhtuan185 @metasal1
+/scripts/strip-fee.sh   @onspeedhp @chauanhtuan185 @metasal1
+/scripts/check-no-fee.sh @onspeedhp @chauanhtuan185 @metasal1

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+<!--
+Keep this short. The squash-merge commit body uses the PR description, so
+prose written here ends up in `git log`. Aim for what a reviewer (or your
+future self bisecting) needs to understand the change.
+
+If this PR cherry-picks from `lazorkit-protocol`: cite the upstream
+commit / PR and confirm `bash scripts/check-no-fee.sh` passes.
+-->
+
+## Summary
+
+<!-- 1–3 bullets: what this PR does and the user-visible reason. -->
+
+## Changes
+
+<!-- Per-file or per-area highlights. Skip if `Summary` already covers it. -->
+
+## Test plan
+
+- [ ] CI passes (`check-no-fee`, `sbf-cluster-check`)
+- [ ] `cargo test --features devnet` passes
+- [ ] `cargo build-sbf --features devnet` and `--features mainnet` both build
+- [ ] `npm test` in `tests-sdk` (against a live validator) passes
+- [ ] Updates docs / CHANGELOG when public behavior changes
+
+## Audit / security notes
+
+<!-- Skip if N/A. Otherwise: error codes touched, account layout changes,
+authority/auth flow changes, vault-invariant defenses, anything that
+needs Accretion follow-up. Note new entries against the
+`audit-baseline-*` tag. -->
+
+## Cherry-pick provenance (if applicable)
+
+<!-- Upstream commit / PR being mirrored from lazorkit-protocol, plus
+confirmation that the fee surface was correctly stripped:
+- [ ] `bash scripts/check-no-fee.sh` clean
+- [ ] No symbols added that match `scripts/fee-paths.txt`
+-->
+
+## Related
+
+<!-- Linked issues, prior PRs, audit findings, design docs. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+# Dependabot config — keep noise low, group updates, monthly cadence.
+# Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Cargo workspace (program + assertions + no-padding)
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    groups:
+      cargo-deps:
+        applies-to: version-updates
+        patterns: ["*"]
+      cargo-security:
+        applies-to: security-updates
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(deps)"
+
+  # Test harness (uses @lazorkit/sdk-legacy from npm)
+  - package-ecosystem: "npm"
+    directory: "/tests-sdk"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    groups:
+      tests-deps:
+        applies-to: version-updates
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(deps-dev)"
+      include: "scope"
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "ci(deps)"


### PR DESCRIPTION
## Summary

Three repo-hygiene additions, all opt-in / non-breaking.

## Files

- **`.github/CODEOWNERS`** — every change requires review from one of \`@onspeedhp\`, \`@chauanhtuan185\`, \`@metasal1\`. Audit-sensitive paths (\`/program/\`, \`/assertions/\`, \`/.github/workflows/\`, \`/audits/\`) and the cherry-pick guardrails (\`scripts/fee-paths.txt\`, \`scripts/strip-fee.sh\`, \`scripts/check-no-fee.sh\`) re-state the same owners so renames don't silently drop ownership rules.

- **`.github/PULL_REQUEST_TEMPLATE.md`** — terse, audit-aware. Includes a "Cherry-pick provenance" section so PRs that mirror commits from \`lazorkit-protocol\` leave a clear trail and explicitly confirm \`bash scripts/check-no-fee.sh\` passed. Note: with squash merge, the PR description ends up as the commit message body on \`main\`, so this template effectively shapes \`git log\` going forward.

- **`.github/dependabot.yml`** — monthly cadence:
  - `cargo` (workspace)
  - `npm` (`/tests-sdk`) — for \`@lazorkit/sdk-legacy\` and vitest
  - `github-actions` (`/`)

  Each ecosystem grouped (1 PR for all version updates, 1 for security) with cap of 2-3 open PRs to keep noise bounded.

## Test plan

- [ ] CI passes — \`check-no-fee\`, \`sbf-cluster-check\` (no source changes)
- [ ] CODEOWNERS auto-assigns reviewers on the next PR
- [ ] First Dependabot run lands within ~30 days